### PR TITLE
base: bibformat migration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,15 @@ recursive-exclude docs/_build *
 
 recursive-include cds/base/static *
 recursive-include cds/base/templates *
+recursive-include cds/base/format_elements *
+recursive-include cds/base/format_templates *
+recursive-include cds/base/output_formats *
+
+recursive-include cds/modules/*/static *
+recursive-include cds/modules/*/templates *
+recursive-include cds/modules/*/format_elements *
+recursive-include cds/modules/*/format_templates *
+recursive-include cds/modules/*/output_formats *
 
 recursive-exclude * *.pyc *.pyo
 

--- a/cds/base/output_formats/HD.bfo
+++ b/cds/base/output_formats/HD.bfo
@@ -1,1 +1,6 @@
+tag 980.a:
+PICTURE --- multimedia/pictures/base.tpl
+PHOTOLAB --- multimedia/pictures/photolab.tpl
+PUBLICVIDEOMOVIE --- multimedia/videos/base.tpl
+PUBLICVIDEORUSH --- multimedia/videos/rush.tpl
 default: Default_HTML_detailed.tpl

--- a/cds/base/templates/format/record/multimedia/layout.tpl
+++ b/cds/base/templates/format/record/multimedia/layout.tpl
@@ -1,0 +1,32 @@
+{#
+## This file is part of CDS.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{%- block header -%}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="page-header">
+                <h2>{{ record.get('title.title', '') }} <br />
+                <span style="font-weight:normal"><i>{{ record.get('title_parallel.title') }}</i></span>
+                </h2>
+            </div>
+        </div>
+    </div>
+{%- endblock -%}
+{%- block body -%}{%- endblock -%}
+{%- block footer -%}{%- endblock -%}

--- a/cds/base/templates/format/record/multimedia/pictures/base.tpl
+++ b/cds/base/templates/format/record/multimedia/pictures/base.tpl
@@ -1,0 +1,51 @@
+{#
+## This file is part of CDS.
+## Copyright (C) 2015 CERN.
+##
+## CDS is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## CDS is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with CDS; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{%- extends "format/record/multimedia/layout.tpl" -%}
+{% import 'records/helpers/multimedia.html' as _multimedia  with context %}
+{% import 'records/helpers/record.html' as _record with context %}
+{%- block body -%}
+    <div class"row">
+        <div class="col-md-3">
+            <dl>
+                <dt><h4><i class="glyphicon glyphicon-camera"></i> Photographer</h4></dt>
+                <dd>{{ _record.author(with_link=True) }}</dd>
+            </dl>
+            <dl>
+                <dt><h4><i class="glyphicon glyphicon-calendar"></i> Date</h4></dt>
+                <dd>{{ _record.date() }}</dd>
+            </dl>
+            <dl>
+                <dt><h4><i class="glyphicon glyphicon-file"></i> Access</h4></dt>
+                <dd>{{ record.get('medium.material') }}</dd>
+            </dl>
+            <dl>
+                <dt><h4><i class="glyphicon glyphicon-tags"></i> &nbsp;Keywords</h4></dt>
+                <dd>{{ _record.keywords(with_link=True) }}</dd>
+            </dl>
+            <hr />
+            <p>{{ _record.copyright() | safe}}</p>
+        </div>
+        <div class="col-md-9">
+            <div class="row">
+                {{ _multimedia.thumbnails() }}
+            </div>
+        </div>
+    </div>
+{%- endblock -%}

--- a/cds/base/templates/format/record/multimedia/pictures/photolab.tpl
+++ b/cds/base/templates/format/record/multimedia/pictures/photolab.tpl
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-##
+{#
 ## This file is part of CDS.
-## Copyright (C) 2013, 2014, 2015 CERN.
+## Copyright (C) 2015 CERN.
 ##
 ## CDS is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -16,25 +15,6 @@
 ## You should have received a copy of the GNU General Public License
 ## along with CDS; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
 
-"""CDS Demosite interface."""
-
-from flask import Blueprint
-from jinja2 import Template
-
-blueprint = Blueprint(
-    'cds', __name__, url_prefix='/', template_folder='templates',
-    static_folder='static'
-)
-
-
-# CDS useful template filters
-# ===========================
-@blueprint.app_template_filter('wrap_with_link')
-def wrap_with_link(value, url="#"):
-    """Wrap a text with html link."""
-    template = Template(
-        "<a href='{{ url }}'>{{ value }}</a>"
-    )
-    data = dict(value=value, url=url)
-    return template.render(**data)
+{%- extends "format/record/multimedia/pictures/base.tpl" -%}

--- a/cds/base/templates/format/record/multimedia/videos/base.tpl
+++ b/cds/base/templates/format/record/multimedia/videos/base.tpl
@@ -16,4 +16,5 @@
 ## along with CDS; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 #}
-{%- extends 'Default_HTML_brief.tpl' -%}
+
+{%- extends "format/record/multimedia/layout.tpl" -%}

--- a/cds/base/templates/format/record/multimedia/videos/rush.tpl
+++ b/cds/base/templates/format/record/multimedia/videos/rush.tpl
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-##
+{#
 ## This file is part of CDS.
-## Copyright (C) 2013, 2014, 2015 CERN.
+## Copyright (C) 2015 CERN.
 ##
 ## CDS is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -16,25 +15,6 @@
 ## You should have received a copy of the GNU General Public License
 ## along with CDS; if not, write to the Free Software Foundation, Inc.,
 ## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
 
-"""CDS Demosite interface."""
-
-from flask import Blueprint
-from jinja2 import Template
-
-blueprint = Blueprint(
-    'cds', __name__, url_prefix='/', template_folder='templates',
-    static_folder='static'
-)
-
-
-# CDS useful template filters
-# ===========================
-@blueprint.app_template_filter('wrap_with_link')
-def wrap_with_link(value, url="#"):
-    """Wrap a text with html link."""
-    template = Template(
-        "<a href='{{ url }}'>{{ value }}</a>"
-    )
-    data = dict(value=value, url=url)
-    return template.render(**data)
+{%- extends "format/record/multimedia/videos/base.tpl" -%}

--- a/cds/base/templates/records/helpers/multimedia.html
+++ b/cds/base/templates/records/helpers/multimedia.html
@@ -1,0 +1,31 @@
+{#
+## This file is part of CDS.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% macro thumbnails(type='field') -%}
+    {# NOTE: It's just for demo proposes
+     # Nothing to do with the production one.
+    #}
+    {% for file in record.get('files') %}
+      <div class="col-md-4">
+          <a href="{{ file.get('url') }}" class="thumbnail">
+            <img src="{{ file.get('url') }}"  style="height:200px!important;max-height:100%;max-width:100%; width:100%!important;" height="200" alt="Text">
+          </a>
+      </div>
+    {% endfor %}
+{%- endmacro %}

--- a/cds/base/templates/records/helpers/record.html
+++ b/cds/base/templates/records/helpers/record.html
@@ -1,0 +1,88 @@
+{#
+## This file is part of CDS.
+## Copyright (C) 2015 CERN.
+##
+## Invenio is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Invenio is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Invenio; if not, write to the Free Software Foundation, Inc.,
+## 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+{% macro copyright(resource_type='photo') %}
+  {% if resource_type == 'photo' %}
+    <div class="cds-copyright-notice text-center">
+      <a href="{{ record.coyright.get('url') | default('http://copyright.web.cern.ch/') | safe }}">{{ _('Conditions of Use') }}</a> &copy; {{ record.coyright.get('date') | safe }} {{ record.coyright.get('holder')| default('CERN') | safe}}
+    </div>
+  {% endif %}
+{% endmacro %}
+
+{% macro author(type='list', with_link=False, separator=', ') %}
+    {% set authors = record.get('authors[:].full_name', []) %}
+    {{ _resolve_output_type(items=authors, with_link=with_link, separator=separator, type=type, query='author:%s') }}
+{% endmacro %}
+
+{% macro keywords(type='labels', with_link=False, separator=', ') %}
+    {% set keywords = record.get('keywords[:].term', []) %}
+    {{ _resolve_output_type(items=keywords, with_link=with_link, separator=separator, type=type, query='keyword:%s') }}
+{% endmacro %}
+
+{% macro date() %}
+  {{ record.creation_date | invenio_format_date() }}
+{% endmacro %}
+
+{# Output resovler #}
+{% macro _resolve_output_type(items, with_link, type, separator, query) %}
+  {% if type == 'list' %}
+    {{ _items_as_list(items, with_link=with_link, query=query) }}
+  {% elif type == 'labels' %}
+    {{ _items_as_labels(items, with_link=with_link, query=query) }}
+  {% else %}
+    {{ _items_with_separator(items, separator=separator, with_link=with_link, query=query) }}
+  {% endif %}
+{% endmacro %}
+
+
+{# Wrap an item inside a list #}
+{% macro _items_as_list(items, with_link=False, query="") %}
+  {% if with_link %}
+    {% set query = query | format(items[0]) %}
+    {% set items =  items | map('wrap_with_link', _create_search_url(query=query)) %}
+  {% endif %}
+  {% set items = items | map('prefix', "<li>") | map('suffix', "</li>") %}
+  <ul>
+    {{ items | join('') | safe }}
+  </ul>
+{% endmacro %}
+
+{# Just join the items with a separator #}
+{% macro _items_with_separator(items, separator=';', with_link=False, query="") %}
+  {% if with_link %}
+    {% set query = query | format(items[0]) %}
+    {% set items =  items | map('wrap_with_link', _create_search_url(query=query)) %}
+  {% endif %}
+  {{ items | join(separator) | safe}}
+{% endmacro %}
+
+{# Return items as bootstrap labels #}
+{% macro _items_as_labels(items, color='default', with_link=False, query="") %}
+  {% if with_link %}
+    {% set query = query | format(items[0]) %}
+    {% set items =  items | map('wrap_with_link', _create_search_url(query=query)) %}
+  {% endif %}
+  {% set class = "label label-%s" | format(color)  %}
+  {{ items | map('wrap', prefix="<span class='label label-default'>", suffix="</span>") | join('&nbsp; ') |safe}}
+{% endmacro %}
+
+{# Create a search link for the item #}
+{% macro _create_search_url(endpoint='search.search', query='') %}
+  {{ url_for(endpoint, p=query) }}
+{% endmacro %}

--- a/cds/base/templates/search/collection.html
+++ b/cds/base/templates/search/collection.html
@@ -1,6 +1,6 @@
 {#
 ## This file is part of Invenio.
-## Copyright (C) 2014 CERN.
+## Copyright (C) 2014, 2015 CERN.
 ##
 ## Invenio is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -50,20 +50,4 @@
       {% endif %}
     </div> <!-- .col-md-9 -->
   {% endif %}
-{%- endblock -%}
-{%- block index -%}
-  {%- block index_title %}
-    {%- if collection.collection_children_r %}
-      <div class="row">
-        <div class="col-md-12">
-          <div class="page-header">
-            <h3>
-              {{ collection.name  }}:
-            </h3>
-          </div>
-        </div>
-      </div>
-    {%- endif %}
-  {%- endblock %}
-  {{- super() }}
 {%- endblock -%}


### PR DESCRIPTION
* Migrates `photolab` bibformat to `jinja`.

* Adds macros for each entity `record`, `multimedia` etc.

* Adds `list`, `label`, `separated` views.

* Adds template function `wrap_with_link`.

* NOTE: It's just a proof of concept.

Signed-off-by: Harris Tzovanakis <me@drjova.com>