### PR TITLE
docker: fix ElasticSearch configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,4 +97,3 @@ elasticsearch:
       - ./elasticsearch-docker.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
   ports:
     - "127.0.0.1:29200:9200"
-  read_only: true

--- a/elasticsearch-docker.yml
+++ b/elasticsearch-docker.yml
@@ -16,5 +16,6 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 cluster.name: invenio
+network.bind_host: 0.0.0.0
 http.port: 9200
 http.publish_port: 9200


### PR DESCRIPTION
* Removes ElasticSearch read-only container configuration.
  (addresses #62)

* Modifies the bind_host configuration to permit access from other
  containers. (closes #62)