### PR TITLE
docker: improves image size and build speed with better caching.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,67 +1,72 @@
-#
 # CDS production docker build
-#
-FROM python:3.5
+
+FROM python:3.5-slim
 MAINTAINER CDS <cds-admin@cern.ch>
 
-# Node.js, bower, less, clean-css, uglify-js, requirejs
-RUN apt-get update
-RUN apt-get -qy upgrade --fix-missing --no-install-recommends
-RUN apt-get -qy install --fix-missing --no-install-recommends curl
-RUN curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash -
+ARG TERM=linux
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-RUN apt-get -qy install --fix-missing --no-install-recommends gcc git iojs
+RUN apt-get update \
+    && apt-get -qy upgrade --fix-missing --no-install-recommends \
+    && apt-get -qy install --fix-missing --no-install-recommends \
+        curl \
+        gcc \
+        # Postgres
+        libpq-dev \
+        # python-pillow
+        libjpeg-dev \
+    # Node.js
+    && curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash - \
+    && apt-get -qy install --fix-missing --no-install-recommends \
+        iojs \
 
-# Slim down image
-RUN apt-get clean autoclean
-RUN apt-get autoremove -y
-RUN rm -rf /var/lib/{apt,dpkg}/
-RUN find /usr/share/doc -depth -type f ! -name copyright -delete
-RUN find /usr/share/doc -empty -delete
-RUN rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/*
+    && apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/{apt,dpkg}/ \
+    && rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/* \
+    && find /usr/share/doc -depth -type f ! -name copyright -delete
 
 # Basic Python and Node.js tools
-RUN pip install --upgrade pip setuptools ipython gunicorn
-RUN npm update && npm install --silent -g node-sass clean-css uglify-js requirejs
+RUN pip install --upgrade pip setuptools ipython gunicorn \
+    && npm update \
+    && npm install --silent -g node-sass clean-css uglify-js requirejs
 
-#
+
 # CDS specific
-#
 
 # Pre-install modules for caching
-RUN mkdir -p /usr/local/src/
+COPY ./docker/docker-entrypoint.sh /
 
 # Create instance/static folder
 ENV APP_INSTANCE_PATH /usr/local/var/invenio-instance
 RUN mkdir -p ${APP_INSTANCE_PATH}
+WORKDIR /code/cds
+
+# Copy and install requirements. Faster build utilizing the Docker cache.
+COPY requirements*.txt /code/cds/
+RUN pip install -r requirements.txt --src /usr/local/src
 
 # Copy source code
-COPY . /code
-WORKDIR /code
+COPY . /code/cds/
 
 # Install CDS
-RUN pip install -r requirements.txt --src /usr/local/src
-RUN pip install -e .
-RUN python -O -m compileall .
-
-# Slim down image
-RUN rm -rf /tmp/* /var/tmp/* /var/lib/{cache,log}/ /root/.cache/*
+RUN pip install -e . \
+    && python -O -m compileall .
 
 # Install bower dependencies and build assets.
-RUN cds npm
-WORKDIR ${APP_INSTANCE_PATH}/static
-RUN npm install
-WORKDIR /code
-RUN cds collect -v
-RUN cds assets build
+RUN cds npm \
+    && cd ${APP_INSTANCE_PATH}/static \
+    && npm install \
+    && cd /code/cds \
+    && cds collect -v \
+    && cds assets build
 
-RUN adduser --uid 1000 --disabled-password --gecos '' cds
-#RUN chown -R cds:cds /code /usr/local/var/invenio-instance
-RUN chown -R cds:cds /code ${APP_INSTANCE_PATH}
-
-VOLUME ["/code"]
+RUN adduser --uid 1000 --disabled-password --gecos '' cds \
+    && chown -R cds:cds /code ${APP_INSTANCE_PATH}
 
 USER cds
 
+VOLUME ["/code/cds"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["cds", "run", "-h", "0.0.0.0"]

--- a/cds/modules/records/__init__.py
+++ b/cds/modules/records/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Data model package."""
+
+from __future__ import absolute_import, print_function

--- a/cds/modules/records/data/__init__.py
+++ b/cds/modules/records/data/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Records Data model package."""
+
+from __future__ import absolute_import, print_function

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ web:
     - mq
     - db
   volumes:
-    - ".:/code"
+    - ".:/code/cds"
 worker:
   build: .
   command: "celery worker -A cds.celery --loglevel=INFO"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#set -e
+
+# Reinstalls cds. This is needed if the src is mounted into the container.
+if [ ! -d "CDS.egg-info" ]; then
+    # Command will fail but the needed CDS.egg-info folder is created.
+    pip install -e . > /dev/null 2>&1
+fi
+
+# https://docs.docker.com/engine/reference/builder/#entrypoint
+exec $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,3 @@
 
 # requirements base
 -r requirements.baseline.txt
-
-
--e .


### PR DESCRIPTION
* Changes base image to python:3.5-slim

* Adds libpq-dev for postgres support and libjpeg-dev needed by pillow.

* Combines RUN statements to reduce the image size.

* Adds a docker-entrypoint.

* Fixes the missing python egg folder if the local repository is fresh cloned
  and mounted as volume.

Signed-off-by: David Zerulla <ddaze@outlook.de>