### PR TITLE
search-ui: fix result thumbnail alignment

### DIFF
--- a/cds/modules/theme/static/scss/cds.scss
+++ b/cds/modules/theme/static/scss/cds.scss
@@ -219,7 +219,7 @@ a[ng-click]{
 }
 
 .cds-media-body {
-  width: auto;
+  width: 100%;
 }
 
 .cds-media-summary {


### PR DESCRIPTION
* Aligns thumbnails in results to the right edge of the screen.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>