### PR TITLE
access: record and file permissions

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -31,10 +31,12 @@ import os
 from invenio_oauthclient.contrib import cern
 from invenio_records_rest.facets import range_filter, terms_filter
 
+from .modules.access.access_control import CERNRecordsSearch
+
 
 # Identity function for string extraction
 def _(x):
-    """Indentity function."""
+    """Identity function."""
     return x
 
 ###############################################################################
@@ -155,6 +157,7 @@ RECORDS_REST_ENDPOINTS = dict(
         pid_fetcher='recid',
         search_index='records',
         search_type=None,
+        search_class=CERNRecordsSearch,
         search_factory_imp='invenio_records_rest.query.es_search_factory',
         record_serializers={
             'application/json': ('invenio_records_rest.serializers'
@@ -205,7 +208,8 @@ RECORDS_REST_FACETS = dict(
                       'sound_track_or_separate_title')),
             topic=dict(terms=dict(
                 field='subject_added_entry_topical_term.'
-                      'topical_term_or_geographic_name_entry_element.untouched')),
+                      'topical_term_or_geographic_name_entry_element.untouched'
+            )),
             years=dict(date_histogram=dict(
                 field='imprint.complete_date',
                 interval='year',
@@ -234,8 +238,15 @@ RECORDS_VALIDATION_TYPES = dict(
     array=(list, tuple),
 )
 
-# FIXME: Disable permissions for now.
-RECORDS_UI_DEFAULT_PERMISSION_FACTORY = None
+RECORDS_UI_DEFAULT_PERMISSION_FACTORY = \
+    'cds.modules.access.access_control:cern_read_factory'
+
+###############################################################################
+# Files
+###############################################################################
+FILES_REST_PERMISSION_FACTORY = \
+    'cds.modules.access.access_control:cern_file_read_factory'
+
 
 ###############################################################################
 # Formatter
@@ -291,8 +302,14 @@ USERPROFILES_EMAIL_ENABLED = False
 ###############################################################################
 # OAuth
 ###############################################################################
+
 OAUTHCLIENT_REMOTE_APPS = dict(
     cern=cern.REMOTE_APP,
+)
+#: Credentials for CERN OAuth (must be changed to work).
+CERN_APP_CREDENTIALS = dict(
+    consumer_key='CHANGE_ME',
+    consumer_secret='CHANGE_ME',
 )
 
 ###############################################################################

--- a/cds/modules/access/__init__.py
+++ b/cds/modules/access/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02D111-1307, USA.
+
+from __future__ import absolute_import

--- a/cds/modules/access/access_control.py
+++ b/cds/modules/access/access_control.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+""" Access control package. """
+
+from elasticsearch_dsl.query import Q
+from flask import g
+from invenio_records.api import Record
+from invenio_records_files.models import RecordsBuckets
+from invenio_search import RecordsSearch
+from invenio_search.api import DefaultFilter
+
+
+#
+# Utility functions
+#
+def _get_user_provides():
+    """Extracts the user's provides from g."""
+    return [str(need.value) for need in sorted(g.identity.provides)]
+
+
+def _has_access(data, action='read'):
+    """Check if current user is allowed access to some data."""
+
+    if '_access' not in data:
+        return True
+
+    # Get user's provides
+    user_groups = _get_user_provides()
+
+    # Get bucket's access rights
+    data_groups = data['_access'][action]
+
+    if not data_groups:
+        return True
+
+    return not set(user_groups).isdisjoint(set(data_groups))
+
+
+#
+# Records FIXME consider all actions
+#
+def cern_read_factory(record, *args, **kwargs):
+    """Restrict search results based on CERN groups and user e-mail."""
+
+    def can(self):
+        """Cross-check user's CERN groups with the record's '_access' field."""
+
+        # Get record
+        rec = Record.get_record(record.id)
+        # Check access
+        return _has_access(rec)
+
+    return type('CERNRead', (), {'can': can})()
+
+
+#
+# Files FIXME consider all actions
+#
+def cern_file_factory(bucket, action):
+    """Restrict file access based on CERN groups and user e-mail."""
+
+    def can(self):
+        """Cross-check user's provides with the bucket's '_access' field."""
+
+        # Get record bucket
+        rb = RecordsBuckets.query.filter_by(bucket_id=bucket.id).one()
+        # Get record
+        rec = rb.record.json
+        # Check access
+        return _has_access(rec)
+
+    return type('CERNFileAccess', (), {'can': can})()
+
+
+#
+# Search
+#
+def cern_filter():
+    """Filter list of results."""
+
+    # Get CERN user's provides
+    provides = _get_user_provides()
+
+    # Filter for public records
+    public = Q('missing', field='_access.read')
+    # Filter for restricted records, that the user has access to
+    restricted = Q('terms', **{'_access.read': provides})
+
+    # OR the two filters
+    combined_filter = public | restricted
+
+    return Q('bool', filter=[combined_filter])
+
+
+class CERNRecordsSearch(RecordsSearch):
+    """CERN search class."""
+
+    class Meta:
+        """Configuration for CERN search."""
+        index = '_all'
+        doc_types = None
+        fields = ('*',)
+        default_filter = DefaultFilter(cern_filter)

--- a/cds/modules/records/mappings/records/default-v1.0.0.json
+++ b/cds/modules/records/mappings/records/default-v1.0.0.json
@@ -7,6 +7,14 @@
             "date_detection": true,
             "numeric_detection": true,
             "properties": {
+                "_access": {
+                    "properties": {
+                        "read": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
+                    }
+                },
                 "location": {
                     "properties": {
                         "location": {

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CDS.
+# Copyright (C) 2015 CERN.
+#
+# CDS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CDS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CDS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test access control package."""
+
+from __future__ import absolute_import, print_function
+
+import uuid
+
+from cds.modules.access.access_control import cern_read_factory
+from flask import g
+from flask_principal import RoleNeed, UserNeed
+from invenio_records.api import Record
+from cds.modules.access.access_control import CERNRecordsSearch
+
+
+def mock_provides(needs):
+    """Mock user provides."""
+    g.identity = lambda: None
+    g.identity.provides = needs
+
+
+def test_record_access(db):
+    """Test access control for search."""
+    mock_provides([UserNeed('test@test.ch'), RoleNeed('groupX')])
+
+    def check_record(json, allowed=True):
+        # Create uuid
+        id = uuid.uuid4()
+
+        # Create record
+        rec = type('obj', (object,), {'id': id})
+        Record.create(json, id_=id)
+
+        # Check permission factory
+        factory = cern_read_factory(rec)
+        assert factory.can() if allowed else not factory.can()
+
+    # Check test records
+    check_record({'_access': {'read': ['test@test.ch', 'groupA', 'groupB']}})
+    check_record({'_access': {'read': ['test2@test2.ch', 'groupC']}}, False)
+    check_record({'_access': {'read': ['groupX']}})
+    check_record({'_access': {'read': ['test@test.ch', 'groupA', 'groupB']}})
+    check_record({'_access': {'read': []}})
+
+
+def test_es_filter():
+    """Test query filter based on CERN groups."""
+    mock_provides([UserNeed('test@test.ch'), RoleNeed('groupX')])
+    assert CERNRecordsSearch().to_dict()['query']['bool']['filter'] == [
+        {'bool': {'filter': [{'bool': {
+            'should': [
+                {'missing': {'field': '_access.read'}},
+                {'terms': {'_access.read': ['test@test.ch', 'groupX']}}
+            ]
+        }}]}}
+    ]


### PR DESCRIPTION
* NEW Enables access control on records, based on CERN groups a 
  use belongs to. This information is provided by the CERN OAuth server.

* NEW Enables access control on files, by inheriting them from the 
  record that is linked to the bucket they reside in.

* Updated the ElasticSearch `default-record-v1.0.0` mapping to include 
  the `_access` field.

* FIX Fixes issue with improper insertion of test files by the 
  `cds fixtures files` CLI command.

* Increases test coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>