### PR TITLE
records: addition of CDS recid provider

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -153,7 +153,7 @@ RECORDS_UI_TOMBSTONE_TEMPLATE = "invenio_records_ui/tombstone.html"
 RECORDS_REST_ENDPOINTS = dict(
     recid=dict(
         pid_type='recid',
-        pid_minter='recid',
+        pid_minter='cds_recid',
         pid_fetcher='recid',
         search_index='records',
         search_type=None,
@@ -240,6 +240,10 @@ RECORDS_VALIDATION_TYPES = dict(
 
 RECORDS_UI_DEFAULT_PERMISSION_FACTORY = \
     'cds.modules.access.access_control:cern_read_factory'
+
+# Endpoint and user agent for the cds_recid provider
+RECORDS_ID_PROVIDER_ENDPOINT = \
+    'http://cds-test.cern.ch/batchuploader/allocaterecord'
 
 ###############################################################################
 # Files

--- a/cds/modules/cds_iiif/utils.py
+++ b/cds/modules/cds_iiif/utils.py
@@ -22,7 +22,6 @@
 import tempfile
 
 import wand.image
-
 from invenio_records_files.api import ObjectVersion
 
 

--- a/cds/modules/records/minters.py
+++ b/cds/modules/records/minters.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Persistent identifier minters."""
+
+from __future__ import absolute_import, print_function
+
+from .providers import CDSRecordIdProvider
+
+
+def recid_minter(record_uuid, data):
+    """Mint record identifiers."""
+    assert 'control_number' not in data
+    provider = CDSRecordIdProvider.create(
+        object_type='rec', object_uuid=record_uuid)
+    data['control_number'] = provider.pid.pid_value
+    return provider.pid

--- a/cds/modules/records/providers.py
+++ b/cds/modules/records/providers.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Record ID provider."""
+
+from __future__ import absolute_import, print_function
+
+import requests
+from flask import current_app
+from invenio_pidstore.errors import PersistentIdentifierError
+from invenio_pidstore.models import PIDStatus
+from invenio_pidstore.providers.base import BaseProvider
+
+
+class CDSRecordIdProvider(BaseProvider):
+    """Record identifier provider."""
+
+    pid_type = 'recid'
+    """Type of persistent identifier."""
+
+    pid_provider = None
+    """Provider name.
+
+    The provider name is not recorded in the PID since the provider does not
+    provide any additional features besides creation of record ids.
+    """
+
+    default_status = PIDStatus.RESERVED
+    """Record IDs are by default registered immediately."""
+
+    @classmethod
+    def create(cls, object_type=None, object_uuid=None, **kwargs):
+        """Create a new record identifier."""
+        # Request next integer in recid sequence.
+        assert 'pid_value' not in kwargs
+
+        response = requests.get(
+            current_app.config['RECORDS_ID_PROVIDER_ENDPOINT'],
+            headers={
+                'User-Agent': 'cdslabs'
+            }).text
+
+        if response.strip().lower().startswith('[error]'):
+            raise PersistentIdentifierError(response)
+
+        kwargs['pid_value'] = response
+        kwargs.setdefault('status', cls.default_status)
+        if object_type and object_uuid:
+            kwargs['status'] = PIDStatus.REGISTERED
+        return super(CDSRecordIdProvider, cls).create(
+            object_type=object_type, object_uuid=object_uuid, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ install_requires = [
     'Pillow>=3.2.0',
     'python-slugify>=1.2.0',
     'raven<=5.1.0',
+    'requests>=2.10.0',
     'Wand>=0.4.2',
 ]
 
@@ -167,6 +168,9 @@ setup(
             'cds_records = cds.modules.records.views:blueprint',
             'cds_search_ui = cds.modules.search_ui.views:blueprint',
             'cds_theme = cds.modules.theme.views:blueprint',
+        ],
+        'invenio_pidstore.minters': [
+            'cds_recid = cds.modules.records.minters:recid_minter',
         ],
         'invenio_i18n.translations': [
             'messages = cds',

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CDS.
+# Copyright (C) 2015 CERN.
+#
+# CDS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CDS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CDS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test access control package."""
+
+from __future__ import absolute_import, print_function
+
+import mock
+import pytest
+from cds.modules.records.minters import recid_minter
+from invenio_pidstore.errors import PersistentIdentifierError
+from invenio_pidstore.models import PIDStatus
+
+
+def test_recid_provider():
+    """Test the CDS recid provider."""
+    with mock.patch('requests.get') as httpmock, mock.patch(
+            'invenio_pidstore.models.PersistentIdentifier.create')\
+            as pid_create:
+        pid_create.configure_mock(**{'return_value.pid_provider': None,
+                                     'return_value.pid_value': 1})
+        httpmock.return_value.text = '999999'
+
+        data = dict()
+        uuid = '12345678123456781234567812345678'
+        recid_minter(uuid, data)
+
+        assert data['control_number'] == 1
+        pid_create.assert_called_once_with(
+            'recid', '999999', pid_provider=None, object_type='rec',
+            object_uuid=uuid, status=PIDStatus.REGISTERED)
+
+
+@mock.patch('requests.get')
+def test_recid_provider_exception(httpmock):
+    """Test the CDS recid provider error."""
+    httpmock.return_value.text = '[Error] error'
+    with pytest.raises(PersistentIdentifierError):
+        recid_minter('12345678123456781234567812345678', dict())


### PR DESCRIPTION
* Adds the minter cds_recid that retrieves new recids from a given
  endpoint.  (#161)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>