### PR TITLE
deposit: fixes for publishing deposits

### DIFF
--- a/cds/modules/deposit/static/json/cds_deposit/form.json
+++ b/cds/modules/deposit/static/json/cds_deposit/form.json
@@ -3,10 +3,10 @@
     "type": "fieldset",
     "items": [
       {
-        "key": "basic_info.name",
+        "key": "title.title",
         "title": "Name"
       }, {
-        "key": "basic_info.description",
+        "key": "title.subtitle",
         "title": "Description"
       }
     ]

--- a/cds/modules/migrator/records.py
+++ b/cds/modules/migrator/records.py
@@ -93,7 +93,8 @@ class CDSRecordDump(RecordDump):
             back_marc_record = to_marc21.do(val)
             for key, value in marc_record.items():
                 if value != back_marc_record.get(key):
-                    lossy_fields.append((key, value, back_marc_record.get(key)))
+                    lossy_fields.append((key, value,
+                                         back_marc_record.get(key)))
 
             if lossy_fields:
                 current_app.logger.error(

--- a/cds/modules/records/minters.py
+++ b/cds/modules/records/minters.py
@@ -31,7 +31,7 @@ from .providers import CDSRecordIdProvider
 
 def recid_minter(record_uuid, data):
     """Mint record identifiers."""
-    assert 'control_number' not in data
+    assert 'recid' not in data
     provider = CDSRecordIdProvider.create(
         object_type='rec', object_uuid=record_uuid)
     data['recid'] = int(provider.pid.pid_value)

--- a/tests/unit/test_deposit.py
+++ b/tests/unit/test_deposit.py
@@ -71,7 +71,6 @@ def test_cds_deposit(location):
     """Test CDS deposit creation."""
     deposit = CDSDeposit.create({})
     assert '_buckets' in deposit
-    assert not deposit.is_published()
 
 
 def test_links_filter(location):

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -29,18 +29,17 @@ from __future__ import absolute_import, print_function
 import mock
 import pytest
 from cds.modules.records.minters import recid_minter
-from invenio_pidstore.errors import PersistentIdentifierError
 from invenio_pidstore.models import PIDStatus
 
 
-def test_recid_provider():
+def test_recid_provider(db):
     """Test the CDS recid provider."""
     with mock.patch('requests.get') as httpmock, mock.patch(
             'invenio_pidstore.models.PersistentIdentifier.create')\
             as pid_create:
         pid_create.configure_mock(**{'return_value.pid_provider': None,
                                      'return_value.pid_value': 1})
-        httpmock.return_value.text = '999999'
+        httpmock.return_value.text = '1'
 
         data = dict()
         uuid = '12345678123456781234567812345678'
@@ -48,13 +47,11 @@ def test_recid_provider():
 
         assert data['recid'] == 1
         pid_create.assert_called_once_with(
-            'recid', '999999', pid_provider=None, object_type='rec',
+            'recid', '1', pid_provider=None, object_type='rec',
             object_uuid=uuid, status=PIDStatus.REGISTERED)
 
 
-@mock.patch('requests.get')
-def test_recid_provider_exception(httpmock):
-    """Test the CDS recid provider error."""
-    httpmock.return_value.text = '[Error] error'
-    with pytest.raises(PersistentIdentifierError):
-        recid_minter('12345678123456781234567812345678', dict())
+def test_recid_provider_exception(db):
+    """Test if providing a recid will cause an error."""
+    with pytest.raises(AssertionError):
+        recid_minter('12345678123456781234567812345678', dict({'recid': 1}))


### PR DESCRIPTION
* Removes is_published and _process_files from CDSDeposit as they are
  not needed.

* Updates schema form for deposit and the corresponding mappings.

* Changes the provider, so in the DEBUG mode, it doesn't contact the
  RECORDS_ID_PROVIDER_ENDPOINT but generates the pid localy.

* Bumps deposit version.

Signed-off-by: Sebastian Witowski <witowski.sebastian@gmail.com>