### PR TITLE
webhook: pickle as accept content

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -71,7 +71,7 @@ CELERY_RESULT_BACKEND = os.environ.get(
 # Celery monitoring.
 CELERY_TRACK_STARTED = True
 # Celery accepted content types.
-CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml']
+CELERY_ACCEPT_CONTENT = ['json', 'msgpack', 'yaml', 'pickle']
 # Celery Beat schedule
 CELERYBEAT_SCHEDULE = {
     'indexer': {

--- a/cds/modules/webhooks/tasks.py
+++ b/cds/modules/webhooks/tasks.py
@@ -180,7 +180,7 @@ def video_metadata_extraction(self, uri, object_version, deposit_id,
             deposit_id=deposit_id,
             event_id=kwargs.get('event_id', None), )
 
-        recid = PersistentIdentifier.get('depid', deposit_id).object_uuid
+        recid = str(PersistentIdentifier.get('depid', deposit_id).object_uuid)
 
         # Extract video's metadata using `ff_probe`
         metadata = json.loads(ff_probe_all(uri))


### PR DESCRIPTION
* Adds pickle to ``CELERY_ACCEPT_CONTENT`` as chain and group are not
  JSON serializable.

* Casts record UUID to string when scheduling ``update_record`` task.