### PR TITLE
docker: fix installation procedures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
         libssl-dev \
         libxml2-dev \
         libxslt-dev \
+        imagemagick \
     # Node.js
     && curl -sL https://deb.nodesource.com/setup_iojs_2.x | bash - \
     && apt-get -qy install --fix-missing --no-install-recommends \
@@ -36,11 +37,12 @@ RUN apt-get update \
     && rm -rf /usr/share/man/* /usr/share/groff/* /usr/share/info/* \
     && find /usr/share/doc -depth -type f ! -name copyright -delete
 
-# Basic Python and Node.js tools
-RUN pip install --upgrade pip setuptools ipython gunicorn \
-    && npm update \
-    && npm install --silent -g node-sass clean-css uglify-js requirejs
+# Basic Python tools
+RUN pip install --upgrade pip setuptools ipython gunicorn
 
+# NPM
+COPY ./scripts/setup-npm.sh /tmp
+RUN /tmp/setup-npm.sh
 
 # CDS specific
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -117,11 +117,11 @@ Next, create the database, indexes, fixtures and an admin user:
 
 .. code-block:: console
 
-    $ docker-compose run web cds db create
-    $ docker-compose run web cds index init
-    $ docker-compose run web cds users create cds@cern.ch -a
-    $ docker-compose run web cds access allow admin-access -e cds@cern.ch
-    $ docker-compose run web cds fixtures cds
+    $ docker-compose run --rm web cds db create
+    $ docker-compose run --rm web cds index init
+    $ docker-compose run --rm web cds users create cds@cern.ch -a
+    $ docker-compose run --rm web cds access allow admin-access user cds@cern.ch
+    $ docker-compose run --rm web cds fixtures cds
 
 Now visit the following URL in your browser:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ frontend:
     - static
 web:
   build: .
-  command: cds --debug run -h 0.0.0.0 -p 5000
+  command: cds run -h 0.0.0.0 -p 5000
   ports:
     - "5000:5000"
   environment:

--- a/docker/es/Dockerfile
+++ b/docker/es/Dockerfile
@@ -1,2 +1,3 @@
-FROM elasticsearch:2.1
+FROM elasticsearch:2.2
 RUN plugin install royrusso/elasticsearch-HQ/2.0.3
+RUN plugin install mapper-attachments


### PR DESCRIPTION
* Fixes Docker-based installation procedures by (i) including necessary
  prerequisites (imagemagick), (ii) updating runtime instructions for Flask
  0.11, (iii) installing appropriate npm package versions. (iv) installing
  Elasticsearch mapper-attachments plugin.

* This makes the site installable via Docker, although further improvements are
  necessary, e.g. regarding fixtures and `imprint._complete_date`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>