### PR TITLE
xrootd: initial module

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -270,6 +270,9 @@ RECORDS_ID_PROVIDER_ENDPOINT = \
 FILES_REST_PERMISSION_FACTORY = \
     'cds.modules.access.access_control:cern_file_factory'
 
+# Files storage
+FIXTURES_FILES_LOCATION = os.environ.get('APP_FIXTURES_FILES_LOCATION', '/tmp')
+
 
 ###############################################################################
 # Formatter
@@ -374,13 +377,6 @@ PREVIEWER_PREFERENCE = [
     'cds_video',
     'zip',
 ]
-
-###############################################################################
-# Storage
-###############################################################################
-
-# FIXME: Add proper data location
-DATADIR = '/tmp'
 
 ###############################################################################
 # Logging

--- a/cds/modules/fixtures/cli.py
+++ b/cds/modules/fixtures/cli.py
@@ -194,7 +194,7 @@ def files(temp, source):
 
     files = _handle_source(source, temp)
 
-    d = current_app.config['DATADIR']
+    d = current_app.config['FIXTURES_FILES_LOCATION']
     if not exists(d):
         makedirs(d)
 

--- a/cds/modules/xrootd/__init__.py
+++ b/cds/modules/xrootd/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""XRootD extension."""
+
+from __future__ import absolute_import, print_function
+
+from .ext import CDSXRootD
+
+__all__ = ('CDSXRootD', )

--- a/cds/modules/xrootd/ext.py
+++ b/cds/modules/xrootd/ext.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2016 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Initialization of XRootD."""
+
+from __future__ import absolute_import, print_function
+
+from pkg_resources import DistributionNotFound, get_distribution
+
+try:
+    # Import XRootDPyFS if available so opener gets registered on
+    # PyFilesystem.
+    get_distribution('xrootdpyfs')
+    import xrootdpyfs  # noqa
+    XROOTD_ENABLED = True
+except DistributionNotFound:
+    XROOTD_ENABLED = False
+    xrootdpyfs = None
+
+
+class CDSXRootD(object):
+    """CDS xrootd extension."""
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        app.config['XROOTD_ENABLED'] = XROOTD_ENABLED
+        if XROOTD_ENABLED:
+            #: Overwrite reported checksum from CERN EOS (due to XRootD 3.3.6).
+            app.config['XROOTD_CHECKSUM_ALGO'] = 'md5'
+            app.config['FILES_REST_STORAGE_FACTORY'] = \
+                'invenio_xrootd:eos_storage_factory'
+        app.extensions['cds-xrootd'] = self

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,12 @@ extras_require['all'] = []
 for name, reqs in extras_require.items():
     extras_require['all'].extend(reqs)
 
+# Do not include in all requirement
+extras_require['xrootd'] = [
+    'invenio-xrootd>=1.0.0a3',
+    'xrootdpyfs>=0.1.3',
+]
+
 setup_requires = [
     'Babel>=1.3',
     'setuptools>=20.6.7',
@@ -171,10 +177,12 @@ setup(
         ],
         'invenio_base.api_apps': [
             'cds_iiif = cds.modules.cds_iiif:CDSIIIF',
+            'cds_xrootd = cds.modules.xrootd:CDSXRootD',
         ],
         'invenio_base.apps': [
             'cds_main_fixtures = cds.modules.fixtures:CDSFixtures',
             'flask_debugtoolbar = flask_debugtoolbar:DebugToolbarExtension',
+            'cds_xrootd = cds.modules.xrootd:CDSXRootD',
         ],
         'invenio_base.blueprints': [
             'cds_deposit = cds.modules.deposit.views:blueprint',


### PR DESCRIPTION
* Adds module for ensuring XRootDPyFS gets loaded when available
  in order for PyFilesystem opener to understand root:// URLs.

To install it pip install -e .[xrootd]