### PR TITLE
deposit: report number generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ services:
 - redis
 - rabbitmq
 env:
-- REQUIREMENTS=production E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
+# - REQUIREMENTS=production E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
 # - REQUIREMENTS=production E2E="yes" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
-- REQUIREMENTS=release E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
+# - REQUIREMENTS=release E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
 # - REQUIREMENTS=release E2E="yes" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
 - REQUIREMENTS=devel E2E="no" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1
 # - REQUIREMENTS=devel E2E="yes" SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/cds" ES_VERSION=2.2.0 ES_HOST=127.0.0.1

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -389,6 +389,9 @@ class Video(CDSDeposit):
         """Publish a video and update the related project."""
         # save a copy of the old PID
         video_old_id = self['_deposit']['id']
+        # inherit ``category`` and ``type`` fields from parent project
+        self['category'] = self.project['category']
+        self['type'] = self.project['type']
         # publish the video
         video_published = super(Video, self).publish(pid=pid, id_=id_)
         (_, record_new) = self.fetch_published()

--- a/cds/modules/records/mappings/records/project-v1.0.0.json
+++ b/cds/modules/records/mappings/records/project-v1.0.0.json
@@ -121,6 +121,12 @@
                     },
                     "type": "object"
                 },
+                "category": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
                 "creator": {
                     "properties": {
                         "contribution": {

--- a/cds/modules/records/mappings/records/project-v1.0.0.json
+++ b/cds/modules/records/mappings/records/project-v1.0.0.json
@@ -127,6 +127,17 @@
                 "type": {
                     "type": "string"
                 },
+                "report_number": {
+                    "properties": {
+                        "_report_number": {
+                            "type": "string"
+                        },
+                        "report_number": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
                 "creator": {
                     "properties": {
                         "contribution": {

--- a/cds/modules/records/mappings/records/video-v1.0.0.json
+++ b/cds/modules/records/mappings/records/video-v1.0.0.json
@@ -241,6 +241,17 @@
                 },
                 "type": {
                     "type": "string"
+                },
+                "report_number": {
+                    "properties": {
+                        "_report_number": {
+                            "type": "string"
+                        },
+                        "report_number": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "date_detection": true

--- a/cds/modules/records/mappings/records/video-v1.0.0.json
+++ b/cds/modules/records/mappings/records/video-v1.0.0.json
@@ -235,6 +235,12 @@
                             "index": "not_analyzed"
                         }
                     }
+                },
+                "category": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
                 }
             },
             "date_detection": true

--- a/cds/modules/records/minters.py
+++ b/cds/modules/records/minters.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import, print_function
 
-from .providers import CDSRecordIdProvider
+from .providers import CDSRecordIdProvider, CDSReportNumberProvider
 
 
 def recid_minter(record_uuid, data):
@@ -36,3 +36,11 @@ def recid_minter(record_uuid, data):
         object_type='rec', object_uuid=record_uuid)
     data['recid'] = int(provider.pid.pid_value)
     return provider.pid
+
+
+def report_number_minter(record_uuid, data, **kwargs):
+    """Mint report number."""
+    provider = CDSReportNumberProvider.create(
+        object_type='rec', object_uuid=record_uuid, data=data, **kwargs)
+    data['report_number'] = dict(report_number=provider.pid.pid_value)
+    return provider.pid.pid_value

--- a/cds/modules/records/providers.py
+++ b/cds/modules/records/providers.py
@@ -73,5 +73,32 @@ class CDSRecordIdProvider(BaseProvider):
         kwargs.setdefault('status', cls.default_status)
         if object_type and object_uuid:
             kwargs['status'] = PIDStatus.REGISTERED
+
         return super(CDSRecordIdProvider, cls).create(
+            object_type=object_type, object_uuid=object_uuid, **kwargs)
+
+
+class CDSReportNumberProvider(BaseProvider):
+    """Report number provider."""
+
+    pid_type = 'rn'
+    """Type of persistent identifier."""
+
+    pid_provider = None
+    """Name of provider."""
+
+    default_status = PIDStatus.RESERVED
+    """Report numbers are by default registered immediately."""
+
+    @classmethod
+    def create(cls, object_type=None, object_uuid=None, data=None, **kwargs):
+        """Create a new report number."""
+        sequence_generator, kwargs = data.get_report_number_sequence(**kwargs)
+        kwargs['pid_value'] = sequence_generator.next()
+
+        kwargs.setdefault('status', cls.default_status)
+        if object_type and object_uuid:
+            kwargs['status'] = PIDStatus.REGISTERED
+
+        return super(CDSReportNumberProvider, cls).create(
             object_type=object_type, object_uuid=object_uuid, **kwargs)

--- a/cds/modules/records/serializers/schemas/json/common.py
+++ b/cds/modules/records/serializers/schemas/json/common.py
@@ -146,3 +146,10 @@ class BucketSchema(StrictKeysSchema):
 
     deposit = fields.Str()
     record = fields.Str()
+
+
+class ReportNumberSchema(StrictKeysSchema):
+    """ReportNumber schema."""
+
+    report_number = fields.Str()
+    _report_number = fields.Str()

--- a/cds/modules/records/serializers/schemas/project.py
+++ b/cds/modules/records/serializers/schemas/project.py
@@ -74,3 +74,6 @@ class ProjectSchema(StrictKeysSchema):
     title = fields.Nested(TitleSchema)
     title_translations = fields.Nested(TitleTranslationSchema, many=True)
     videos = fields.Nested(ProjectVideoSchema, many=True)
+
+    category = fields.Str()
+    type = fields.Str()

--- a/cds/modules/records/serializers/schemas/project.py
+++ b/cds/modules/records/serializers/schemas/project.py
@@ -25,7 +25,7 @@ from cds.modules.records.serializers.schemas.json.common import \
     StrictKeysSchema, AccessSchema, DescriptionSchema, KeywordsSchema, \
     ContributorSchema, TitleTranslationSchema, OaiSchema, \
     DescriptionTranslationSchema, DepositSchema, CreatorSchema, TitleSchema, \
-    BucketSchema
+    BucketSchema, ReportNumberSchema
 from marshmallow import fields
 
 
@@ -77,3 +77,4 @@ class ProjectSchema(StrictKeysSchema):
 
     category = fields.Str()
     type = fields.Str()
+    report_number = fields.Nested(ReportNumberSchema, many=False)

--- a/cds/modules/records/serializers/schemas/video.py
+++ b/cds/modules/records/serializers/schemas/video.py
@@ -81,3 +81,6 @@ class VideoSchema(StrictKeysSchema):
     schema = fields.Str(attribute="$schema")
     title = fields.Nested(TitleSchema)
     title_translations = fields.Nested(TitleTranslationSchema, many=True)
+
+    category = fields.Str()
+    type = fields.Str()

--- a/cds/modules/records/serializers/schemas/video.py
+++ b/cds/modules/records/serializers/schemas/video.py
@@ -24,7 +24,8 @@ from __future__ import absolute_import
 from cds.modules.records.serializers.schemas.json.common import \
     StrictKeysSchema, ContributorSchema, KeywordsSchema, DescriptionSchema, \
     BucketSchema, OaiSchema, CreatorSchema, DescriptionTranslationSchema, \
-    DepositSchema, TitleTranslationSchema, TitleSchema, AccessSchema
+    DepositSchema, TitleTranslationSchema, TitleSchema, AccessSchema, \
+    ReportNumberSchema
 from marshmallow import fields
 
 
@@ -84,3 +85,4 @@ class VideoSchema(StrictKeysSchema):
 
     category = fields.Str()
     type = fields.Str()
+    report_number = fields.Nested(ReportNumberSchema, many=False)

--- a/requirements.devel.txt
+++ b/requirements.devel.txt
@@ -45,7 +45,7 @@ SQLAlchemy-Continuum>=1.2.1 # dependency of invenio-db
 -e git+https://github.com/inveniosoftware/invenio-config.git#egg=invenio-config
 -e git+https://github.com/inveniosoftware/invenio-db.git#egg=invenio-db
 -e git+https://github.com/inveniosoftware/invenio-deposit.git#egg=invenio-deposit
-# FIXME
+# FIXME wait for PR#132
 # -e git+https://github.com/inveniosoftware/invenio-files-rest.git#egg=invenio-files-rest
 -e git+https://github.com/egabancho/invenio-files-rest.git@object-version-tags#egg=invenio-files-rest
 -e git+https://github.com/inveniosoftware/invenio-formatter.git#egg=invenio-formatter
@@ -68,11 +68,12 @@ SQLAlchemy-Continuum>=1.2.1 # dependency of invenio-db
 -e git+https://github.com/inveniosoftware/invenio-rest.git#egg=invenio-rest
 -e git+https://github.com/inveniosoftware/invenio-search-ui.git#egg=invenio-search-ui
 -e git+https://github.com/inveniosoftware/invenio-search.git#egg=invenio-search
-# FIXME wait invenio-sse is released on inveniosoftware
+-e git+https://github.com/inveniosoftware/invenio-sequencegenerator.git#egg=invenio-sequencegenerator
+# FIXME wait for invenio-sse release
 # -e git+https://github.com/inveniosoftware/invenio-sse.git#egg=invenio-sse
 -e git+https://github.com/egabancho/invenio-sse.git#egg=invenio-sse
 -e git+https://github.com/inveniosoftware/invenio-theme.git#egg=invenio-theme
 -e git+https://github.com/inveniosoftware/invenio-userprofiles.git#egg=invenio-userprofiles
-# FIXME Need to fix json columns on webhooks
+# FIXME wait for PR#50
 # -e git+https://github.com/inveniosoftware/invenio-webhooks.git#egg=invenio-webhooks
 -e git+https://github.com/hachreak/invenio-webhooks.git@fix_json#egg=invenio-webhooks

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,9 @@ install_requires = [
     'invenio-rest[cors]>=1.0.0a9',
     'invenio-search-ui>=1.0.0a5',
     'invenio-search>=1.0.0a7',
-    # FIXME wait invenio-sse is released
+    # FIXME wait until invenio-sequencegenerator is released
+    #  'invenio-sequencegenerator>=1.0.0a1',
+    # FIXME wait until invenio-sse is released
     #  'invenio-sse>=1.0.0a1',
     'invenio-theme>=1.0.0a14',
     'invenio-userprofiles>=1.0.0a7',
@@ -202,6 +204,8 @@ setup(
         'invenio_pidstore.minters': [
             'cds_recid = cds.modules.records.minters:recid_minter',
             'cds_catid = cds.modules.deposit.minters:catid_minter',
+            'cds_report_number = '
+            'cds.modules.records.minters:report_number_minter',
         ],
         # FIXME removed until proper integration
         # 'invenio_i18n.translations': [

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -400,6 +400,9 @@ def project_metadata():
                 'role': 'Editor'
             }
         ],
+        'date': '2016-12-03T00:00:00Z',
+        'category': 'CERN',
+        'type': 'MOVIE',
     }
 
 
@@ -436,6 +439,9 @@ def project(app, deposit_rest, es, cds_jsonresolver, users, location, db):
         'description': {
             'value': 'in tempor reprehenderit enim eiusmod',
         },
+        'date': '2016-12-03T00:00:00Z',
+        'category': 'CERN',
+        'type': 'MOVIE',
     }
     project_video_1 = {
         'title': {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -244,7 +244,10 @@ def depid(app, users, db):
 def cds_depid(api_app, users, db, bucket):
     """New deposit with files."""
     record = {
-        'title': {'title': 'fuu'}
+        'title': {'title': 'fuu'},
+        'date': '2016-12-03T00:00:00Z',
+        'category': 'CERN',
+        'type': 'MOVIE',
     }
     with api_app.test_request_context():
         login_user(User.query.get(users[0]))

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -30,6 +30,7 @@ import mock
 import pytest
 import uuid
 
+from cds.modules.records.providers import CDSRecordIdProvider
 from flask_security import login_user
 from cds.modules.deposit.api import (record_build_url, Project, Video,
                                      video_resolver, video_build_url,

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -343,3 +343,17 @@ def test_project_delete_one_video_published(app, project, force):
     #  project_id = video_1.project.id
 
     #  project.delete(force=force)
+
+
+def test_inheritance(app, project):
+    """Test that videos inherit the proper fields from parent project."""
+    (project, video, _) = project
+    assert 'category' in project
+    assert 'type' in project
+
+    # Publish the video
+    video = video.publish()
+    assert 'category' in video
+    assert 'type' in video
+    assert video['category'] == project['category']
+    assert video['type'] == project['type']

--- a/tests/unit/test_report_number_generation.py
+++ b/tests/unit/test_report_number_generation.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CDS.
+# Copyright (C) 2016 CERN.
+#
+# CDS is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CDS is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CDS; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test CDS report number generation."""
+
+from __future__ import absolute_import, print_function
+
+from cds.modules.deposit.api import video_resolver, project_resolver, Project
+
+
+def video_resolver_sorted(ids):
+    """Return videos with ascending RN order."""
+    return sorted(video_resolver(ids), key=lambda x: x.report_number)
+
+
+def check_deposit(dep, expected_rn):
+    """Check that a deposit has properly generated its report number."""
+    assert 'recid' in dep
+    stored = project_resolver(str(dep['recid'])) \
+        if isinstance(dep, Project) else video_resolver([str(dep['recid'])])[0]
+    for rec in [dep, stored]:
+        assert rec.report_number
+        assert rec.report_number == expected_rn
+
+
+def test_one_video(app, db, project):
+    check_deposit(project[1].publish(), 'CERN-MOVIE-2016-1-1'.format())
+
+
+def test_only_videos(app, db, project):
+    (project, video_1, video_2) = project
+    for i, video in enumerate([video_1, video_2]):
+        video = video.publish()
+        check_deposit(video, 'CERN-MOVIE-2016-1-{}'.format(i + 1))
+
+
+def test_only_project(app, db, project):
+    check_deposit(project[0].publish(), 'CERN-MOVIE-2016-1')
+
+
+def test_project_and_videos(app, db, project):
+    (project, video_1, video_2) = project
+    project = project.publish()
+    check_deposit(project, 'CERN-MOVIE-2016-1')
+    for i, video in enumerate(video_resolver_sorted(project.video_ids)):
+        check_deposit(video, 'CERN-MOVIE-2016-1-{}'.format(i))
+
+
+def test_video_then_project(app, db, project):
+    (project, video_1, video_2) = project
+    video_1 = video_1.publish()
+    check_deposit(video_1, 'CERN-MOVIE-2016-1-1')
+
+    project = video_1.project
+    project = project.publish()
+    check_deposit(project, 'CERN-MOVIE-2016-1')
+
+    video_2 = video_resolver_sorted(project.video_ids)[1]
+    check_deposit(video_2, 'CERN-MOVIE-2016-1-2')

--- a/tests/unit/test_video.py
+++ b/tests/unit/test_video.py
@@ -144,7 +144,7 @@ def test_delete_video_not_published(project, force):
 
     video_2_meta = RecordMetadata.query.filter_by(id=video_2_id).first()
     if force:
-        video_2_meta is None
+        assert video_2_meta is None
     else:
         assert video_2_meta.json is None
 


### PR DESCRIPTION
 * Generates report numbers for projects and videos. (closes #187)

 * Updates Elasticsearch mappings to include `report_number`.

 * Updates schemas for serializers.

 * Adds tests for coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>