### PR TITLE
webhooks: undo-able tasks

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -118,7 +118,7 @@ def app():
 
 @pytest.yield_fixture(scope='session')
 def celery_not_fail_on_eager_app(app):
-    """."""
+    """Celery configuration that does not raise errors inside test."""
     instance_path = tempfile.mkdtemp()
     sorenson_output = tempfile.mkdtemp()
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -31,7 +31,7 @@ from celery import shared_task, states
 from cds.modules.deposit.minters import catid_minter
 from invenio_indexer.api import RecordIndexer
 
-from cds.modules.webhooks.tasks import _factory_sse_task_base
+from cds.modules.webhooks.tasks import _factory_avc_task_base
 from cds.modules.deposit.api import Category
 
 
@@ -47,14 +47,14 @@ def success_task(self, *args, **kwargs):
     self.update_state(state=states.SUCCESS, meta={})
 
 
-@shared_task(bind=True, base=_factory_sse_task_base(type_='simple_failure'))
+@shared_task(bind=True, base=_factory_avc_task_base(type_='simple_failure'))
 def sse_failing_task(self, *args, **kwargs):
     """A failing shared task."""
     self.update_state(
         state=states.FAILURE, meta={'exc_type': 'fuu', 'exc_message': 'fuu'})
 
 
-@shared_task(bind=True, base=_factory_sse_task_base(type_='simple_failure'))
+@shared_task(bind=True, base=_factory_avc_task_base(type_='simple_failure'))
 def sse_success_task(self, *args, **kwargs):
     """A failing shared task."""
     self.update_state(state=states.SUCCESS, meta={})
@@ -66,7 +66,7 @@ def simple_add(x, y):
     return x + y
 
 
-@shared_task(bind=True, base=_factory_sse_task_base(type_='simple_add'))
+@shared_task(bind=True, base=_factory_avc_task_base(type_='simple_add'))
 def sse_simple_add(self, x, y, **kwargs):
     """Simple shared task."""
     self._base_payload = {"deposit_id": kwargs.get('deposit_id')}

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -31,7 +31,7 @@ import json
 import mock
 from flask import url_for
 
-from invenio_files_rest.models import ObjectVersion
+from invenio_files_rest.models import ObjectVersion, as_object_version
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records import Record
 import pytest


### PR DESCRIPTION
* Adds resource de-allocation for every webhooks task via the `undo`
   method. This will be used by the receiver's `DELETE` request handler.
   (closes #316)

 * Every task of the AVC workflow can now be undone by appending
   `undo=True` to the original arguments.

 * Adds tests for coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>