### PR TITLE
webhooks: multiple transcoding tasks

### DIFF
--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -234,7 +234,7 @@ def test_transcode(db, bucket, mock_sorenson):
     assert get_bucket_keys() == ['test.pdf']
 
     video_transcode.delay(obj.version_id,
-                          video_presets=['Youtube 480p'],
+                          preset='Youtube 480p',
                           sleep_time=0)
 
     db.session.add(bucket)


### PR DESCRIPTION
 * Changes execution of the video transcoding to spawn multiple Celery
   tasks instead of one (i.e. one task for each video preset).

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>