### PR TITLE
ffmpeg: automatic calculation of aspect ratio

### DIFF
--- a/cds/modules/ffmpeg/__init__.py
+++ b/cds/modules/ffmpeg/__init__.py
@@ -21,6 +21,6 @@
 
 from __future__ import absolute_import, print_function
 
-from .ffmpeg import ff_frames, ff_probe, ff_probe_all
+from .ffmpeg import ff_frames, ff_probe, ff_probe_all, valid_aspect_ratios
 
-__all__ = ('ff_frames', 'ff_probe', 'ff_probe_all')
+__all__ = ('ff_frames', 'ff_probe', 'ff_probe_all', 'valid_aspect_ratios')

--- a/tests/unit/test_ffmpeg.py
+++ b/tests/unit/test_ffmpeg.py
@@ -31,7 +31,9 @@ import tempfile
 from os import listdir
 from os.path import isfile, join, dirname
 import json
-from cds.modules.ffmpeg import ff_frames, ff_probe, ff_probe_all
+
+from cds.modules.ffmpeg import ff_frames, ff_probe, ff_probe_all, \
+    valid_aspect_ratios
 
 
 def test_ffprobe_mp4(video_mp4):
@@ -90,3 +92,13 @@ def test_ffprobe_all(online_video):
     format_keys = ['filename', 'nb_streams', 'format_name', 'format_long_name',
                    'start_time', 'duration', 'size', 'bit_rate', 'tags']
     assert all([key in information['format'] for key in format_keys])
+
+
+def test_aspect_ratio(video_mp4, video_mov, online_video):
+    """Test calculation of video's aspect ratio."""
+    for video in [video_mp4, video_mov, online_video]:
+        metadata = json.loads(ff_probe_all(video))['streams'][0]
+        for aspect_ratio in [ff_probe(video, 'display_aspect_ratio'),
+                             metadata['display_aspect_ratio']]:
+            assert aspect_ratio in ['{}:{}'.format(w, h)
+                                    for (w, h) in valid_aspect_ratios()]

--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -174,7 +174,7 @@ def test_metadata_extraction_video_mp4(app, db, cds_depid, bucket, video_mp4):
     assert tags['width'] == '640'
     assert tags['height'] == '360'
     assert tags['nb_frames'] == '1440'
-    assert tags['display_aspect_ratio'] == '0:1'
+    assert tags['display_aspect_ratio'] == '16:9'
     assert tags['color_range'] == 'tv'
 
     # Undo


### PR DESCRIPTION
 * Calculates aspect ratio from a video's dimensions, in case it is
   missing from its metadata information. (closes #351)

 * Adds tests for coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>