### PR TITLE
webhooks: event deletion removal

### DIFF
--- a/cds/modules/webhooks/receivers.py
+++ b/cds/modules/webhooks/receivers.py
@@ -238,12 +238,11 @@ class Downloader(CeleryAsyncReceiver):
     def delete(self, event):
         """Delete generated files."""
         super(Downloader, self).delete(event)
-        DownloadTask().clean(version_id=event.response['version_id'])
+        self.clean_task(event=event, task_name='file_download')
 
-    def delete_task(self, event, task_id, *args, **kwargs):
+    def clean_task(self, event, task_name, *args, **kwargs):
         """Delete everything created by a task."""
-        # TODO create a test!
-        if task_id == 'file_download':
+        if task_name == 'file_download':
             DownloadTask().clean(version_id=event.response['version_id'])
 
 
@@ -421,12 +420,10 @@ class AVCWorkflow(CeleryAsyncReceiver):
         if 'version_id' not in event.payload:
             self.clean_task(event=event, task_name='file_download')
         self.clean(event=event)
-        db.session.commit()
 
     def clean(self, event):
         """Delete the event."""
         ObjectVersionTag.query.filter_by(key='_event_id', value=event.id)
-        db.session.delete(event)
 
     def _raw_info(self, event):
         """Get info from the event."""

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -395,7 +395,7 @@ def test_avc_workflow_receiver_pass(api_app, db, bucket, cds_depid,
         assert 'extracted_metadata' not in record.json['_deposit']
 
         # check there are no events
-        assert events == []
+        assert len(events) == 1
 
         # check no SSE message and reindexing is fired
         assert mock_sse.called is False

--- a/tests/unit/test_webhook_status.py
+++ b/tests/unit/test_webhook_status.py
@@ -35,10 +35,10 @@ from helpers import mock_current_user
 
 
 @mock.patch('flask_login.current_user', mock_current_user)
-def test_avc_workflow_receiver_pass(api_app, db, bucket, cds_depid,
-                                    access_token, json_headers, mock_sorenson,
-                                    online_video, webhooks):
-    """Test AVCWorkflow receiver."""
+def test_tasks_status(api_app, db, bucket, cds_depid,
+                      access_token, json_headers, mock_sorenson,
+                      online_video, webhooks):
+    """Test status of tasks."""
     db.session.add(bucket)
     master_key = 'test.mp4'
     with api_app.test_request_context():

--- a/tests/unit/test_webhook_views.py
+++ b/tests/unit/test_webhook_views.py
@@ -35,6 +35,50 @@ from helpers import mock_current_user
 from invenio_files_rest.models import ObjectVersion, \
     ObjectVersionTag, Bucket
 from invenio_records.models import RecordMetadata
+from six import BytesIO
+
+
+def check_restart_avc_workflow(api_app, event_id, access_token,
+                               json_headers, data):
+    """Try to restart AVC workflow via REST API."""
+    with api_app.test_request_context():
+        url = url_for(
+            'invenio_webhooks.event_item',
+            receiver_id='avc',
+            event_id=event_id,
+            access_token=access_token
+        )
+    with api_app.test_client() as client, \
+            mock.patch('invenio_sse.ext._SSEState.publish') as mock_sse, \
+            mock.patch('invenio_indexer.api.RecordIndexer.bulk_index') \
+            as mock_indexer:
+        sse_channel = 'mychannel'
+        payload = dict(
+            sse_channel=sse_channel
+        )
+        resp = client.put(
+            url, headers=json_headers, data=json.dumps(payload))
+
+        assert resp.status_code == 201
+
+    # 1 master + 2 slave + 90 frames == 93
+    assert ObjectVersion.query.count() == 93
+
+    # check tags
+    assert ObjectVersionTag.query.count() == 200
+
+    # check extracted metadata is there
+    records = RecordMetadata.query.all()
+    assert len(records) == 1
+    assert 'extracted_metadata' in records[0].json['_deposit']
+
+    # check SSE
+    assert mock_sse.called is True
+
+    # check elasticsearch
+    # note: false because the delete doesn't clean event info inside the
+    # deposit and test is in EAGER mode.
+    assert mock_indexer.called is False
 
 
 def check_video_transcode(api_app, event_id, access_token,
@@ -68,7 +112,7 @@ def check_video_transcode(api_app, event_id, access_token,
     # check tags
     assert ObjectVersionTag.query.count() == 196
 
-    # check extracted metadata is not there
+    # check extracted metadata is there
     records = RecordMetadata.query.all()
     assert len(records) == 1
     assert 'extracted_metadata' in records[0].json['_deposit']
@@ -105,14 +149,10 @@ def check_video_transcode(api_app, event_id, access_token,
     # check tags
     assert ObjectVersionTag.query.count() == 192
 
-    # check extracted metadata is not there
+    # check extracted metadata is there
     records = RecordMetadata.query.all()
     assert len(records) == 1
     assert 'extracted_metadata' in records[0].json['_deposit']
-
-    # check bucket size
-    bucket = Bucket.query.first()
-    assert bucket.size == 0
 
 
 def check_video_frames(api_app, event_id, access_token,
@@ -145,14 +185,10 @@ def check_video_frames(api_app, event_id, access_token,
     # check tags
     assert ObjectVersionTag.query.count() == 20
 
-    # check extracted metadata is not there
+    # check extracted metadata is there
     records = RecordMetadata.query.all()
     assert len(records) == 1
     assert 'extracted_metadata' in records[0].json['_deposit']
-
-    # check bucket size
-    bucket = Bucket.query.first()
-    assert bucket.size == 0
 
 
 def check_video_download(api_app, event_id, access_token,
@@ -189,10 +225,6 @@ def check_video_download(api_app, event_id, access_token,
     records = RecordMetadata.query.all()
     assert len(records) == 1
     assert 'extracted_metadata' in records[0].json['_deposit']
-
-    # check bucket size
-    bucket = Bucket.query.first()
-    assert bucket.size == 0
 
 
 def check_video_metadata_extraction(api_app, event_id, access_token,
@@ -233,6 +265,7 @@ def check_video_metadata_extraction(api_app, event_id, access_token,
 
 
 @pytest.mark.parametrize('checker', [
+    check_restart_avc_workflow,
     check_video_metadata_extraction,
     check_video_download,
     check_video_frames,
@@ -242,7 +275,7 @@ def check_video_metadata_extraction(api_app, event_id, access_token,
 def test_avc_workflow_delete(api_app, db, bucket, cds_depid,
                              access_token, json_headers, mock_sorenson,
                              online_video, webhooks, checker):
-    """Test AVCWorkflow receiver."""
+    """Test AVCWorkflow receiver REST API."""
     db.session.add(bucket)
     master_key = 'test.mp4'
 
@@ -284,3 +317,83 @@ def test_avc_workflow_delete(api_app, db, bucket, cds_depid,
     event_id = data['tags']['_event_id']
     ###
     checker(api_app, event_id, access_token, json_headers, data)
+
+
+@mock.patch('flask_login.current_user', mock_current_user)
+def test_download_workflow_delete(api_app, db, bucket, cds_depid,
+                                  access_token, json_headers, mock_sorenson,
+                                  online_video, webhooks):
+    """Test Download receiver REST API."""
+    db.session.add(bucket)
+
+    with api_app.test_request_context():
+        url = url_for(
+            'invenio_webhooks.event_list',
+            receiver_id='downloader',
+            access_token=access_token
+        )
+
+    with mock.patch('requests.get') as mock_request, \
+            api_app.test_client() as client, \
+            mock.patch('invenio_sse.ext._SSEState.publish'), \
+            mock.patch('invenio_indexer.api.RecordIndexer.bulk_index'):
+        sse_channel = 'mychannel'
+        file_size = 1024
+        mock_request.return_value = type(
+            'Response', (object, ), {
+                'raw': BytesIO(b'\x00' * file_size),
+                'headers': {'Content-Length': file_size}
+            })
+
+        payload = dict(
+            uri='http://example.com/test.pdf',
+            bucket_id=str(bucket.id),
+            deposit_id=cds_depid,
+            key='test.pdf',
+            sse_channel=sse_channel
+        )
+        resp = client.post(url, headers=json_headers, data=json.dumps(payload))
+
+        assert resp.status_code == 201
+        data = json.loads(resp.data.decode('utf-8'))
+
+        assert ObjectVersion.query.count() == 1
+        obj = ObjectVersion.query.first()
+        tags = obj.get_tags()
+        assert tags['_event_id'] == data['tags']['_event_id']
+        assert obj.key == data['key']
+        assert str(obj.version_id) == data['version_id']
+        assert obj.file
+        assert obj.file.size == file_size
+
+    with api_app.test_request_context():
+        url = url_for(
+            'invenio_webhooks.event_item',
+            receiver_id='downloader',
+            event_id=data['tags']['_event_id'],
+            access_token=access_token
+        )
+
+    with mock.patch('requests.get') as mock_request, \
+            api_app.test_client() as client, \
+            mock.patch('invenio_sse.ext._SSEState.publish'), \
+            mock.patch('invenio_indexer.api.RecordIndexer.bulk_index'):
+        mock_request.return_value = type(
+            'Response', (object, ), {
+                'raw': BytesIO(b'\x00' * file_size),
+                'headers': {'Content-Length': file_size}
+            })
+
+        resp = client.put(url, headers=json_headers)
+
+        assert resp.status_code == 201
+        data = json.loads(resp.data.decode('utf-8'))
+
+        assert ObjectVersion.query.count() == 1
+        obj = ObjectVersion.query.first()
+        tags = obj.get_tags()
+        assert tags['_event_id'] == data['tags']['_event_id']
+        assert obj.key == data['key']
+        assert str(obj.version_id) == data['version_id']
+        assert obj.file
+        assert obj.file.size == file_size


### PR DESCRIPTION
* Removes event deletion on receiver delete.

* Adds a test to restart the AVC workflow.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>