### PR TITLE
installation: pin clean-css version to 3.4.24

### DIFF
--- a/scripts/setup-npm.sh
+++ b/scripts/setup-npm.sh
@@ -22,4 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-npm update && npm install --silent -g node-sass@3.8.0 clean-css uglify-js requirejs
+# FIXME clean-css version pinned!. See issue #390
+npm update && \
+  npm install --silent -g node-sass@3.8.0 clean-css@3.4.24 uglify-js requirejs


### PR DESCRIPTION
* Sets a pin to the clean-css version installed because of some
  incompatibility. (closes #390)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>