### PR TITLE
deposit: five frames per row

### DIFF
--- a/cds/modules/deposit/static/templates/cds_deposit/types/common/uploader.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/common/uploader.html
@@ -87,7 +87,7 @@
     <tr ng-show="showFrames">
       <td colspan="4">
         <div class="row cds-deposit-thumbnail-pad">
-          <div class="col-sm-2 cds-deposit-thumbnail-pad" ng-repeat="frame in $ctrl.getFrames()">
+          <div class="cds-deposit-frame-thumbnail" ng-repeat="frame in $ctrl.getFrames()">
             <a ng-href="{{ frame.links.self }}" target="_blank">
               <img ng-if="showFrames" width="100%" ng-src="{{ $ctrl.thumbnailPreview(frame.key) }}" />
             </a>

--- a/cds/modules/theme/static/scss/cds.scss
+++ b/cds/modules/theme/static/scss/cds.scss
@@ -228,8 +228,10 @@ a[ng-click]{
   }
 }
 
-.cds-deposit-thumbnail-pad {
+.cds-deposit-frame-thumbnail {
   padding: 5px;
+  width: 20%;
+  float: left;
 }
 
 .cds-deposit-strap-select {


### PR DESCRIPTION
* Changes each row of extracted frames to contain five thumbnails.
  (fixes #437)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>