### PR TITLE
previewer: THEO-VTT integration

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -210,10 +210,18 @@ RECORDS_UI_ENDPOINTS = dict(
     recid_export=dict(
         pid_type='recid',
         route='/record/<pid_value>/export/<any({0}):format>'.format(
-            ", ".join(list(CDS_RECORDS_EXPORTFORMATS.keys()))
+            ", ".join(
+                [k for k in CDS_RECORDS_EXPORTFORMATS.keys() if k != 'vtt']
+            )
         ),
         template='cds_records/record_export.html',
         view_imp='cds.modules.records.views.records_ui_export',
+        record_class='invenio_records_files.api:Record',
+    ),
+    recid_export_vtt=dict(
+        pid_type='recid',
+        route='/record/<pid_value>/export/<any(vtt):format>',
+        view_imp='cds.modules.records.views.records_ui_export_vtt',
         record_class='invenio_records_files.api:Record',
     ),
 )
@@ -491,7 +499,8 @@ THEO_LICENCE_KEY = 'CHANGE_ME'
 # Wowza server URL for m3u8 playlist generation
 WOWZA_PLAYLIST_URL = ('https://wowzaqaedge.cern.ch/cdseos/Video/'
                       '{filepath}/{filename}/playlist.m3u8')
-
+# Thumbnail size
+VIDEO_POSTER_SIZE = (180, 180)
 
 ###############################################################################
 # Logging

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -133,7 +133,7 @@ class CDSFileObject(FileObject):
                 ObjectVersionTag.value == str(self.obj.version_id)
                 ).order_by(func.length(ObjectVersion.key), ObjectVersion.key):
             master_dump.setdefault(
-                slave.get_tags()['type'], []).append(_dumps(slave))
+                slave.get_tags()['context_type'], []).append(_dumps(slave))
         # Sort slaves by key within their lists
         self.data.update(master_dump)
 
@@ -153,6 +153,25 @@ class CDSFilesIterator(FilesIterator):
             if dump:
                 files.append(dump)
         return files
+
+    @staticmethod
+    def get_master_video_file(record):
+        """Get master video file from a Video record."""
+        return next(
+            f for f in record['_files']
+            if f['media_type'] == 'video' and f['context_type'] == 'master')
+
+    @staticmethod
+    def get_video_subformats(master_file):
+        return [video
+                for video in master_file.get('subformat', [])
+                if video['media_type'] == 'video' and video[
+                    'context_type'] == 'subformat']
+
+    @staticmethod
+    def get_video_frames(master_file):
+        return sorted(master_file.get('frame', []),
+                      key=lambda s: s['tags']['timestamp'])
 
 
 class CDSDeposit(Deposit):

--- a/cds/modules/ffmpeg/ffmpeg.py
+++ b/cds/modules/ffmpeg/ffmpeg.py
@@ -111,26 +111,22 @@ def _patch_aspect_ratio(metadata):
 #
 # Frame extraction
 #
-def ff_frames(input_file, start, end, step, output, progress_callback=None):
+def ff_frames(input_file, start, end, step, duration, output,
+              progress_callback=None):
     """Extract requested frames from video.
 
     :param input_file:
-    :param start: percentage of the video to begin extracting frames.
-    :param end: percentage of the video to stop extracting frames.
-    :param step: percentage between of the video between frames.
+    :param start: time position to begin extracting frames.
+    :param end: time position to stop extracting frames.
+    :param step: time interval between frames.
+    :param duration: total duration of the video
     :param output: output folder and format for the file names as in ``ffmpeg``
     , i.e /path/to/somewhere/frames-%d.jpg
     :param progress_callback: function taking as first parameter the number of
     seconds processed and as second parameter the total duration of the video.
     """
-    duration = float(ff_probe(input_file, 'duration'))
-    # Calculate time step
-    time_step = duration * step / 100
-    start_time = duration * start / 100
-    end_time = duration * (end+1) / 100  # end inclusive
-
     cmd = 'ffmpeg -i {0} -ss {1} -to {2} -vf fps=1/{3} {4}'.format(
-        input_file, start_time, end_time, time_step, output
+        input_file, start, end, step, output
     )
 
     thread = pexpect.spawn(cmd)

--- a/cds/modules/previewer/api.py
+++ b/cds/modules/previewer/api.py
@@ -61,10 +61,18 @@ class CDSPreviewRecordFile(PreviewFile):
             filename='frame-1.jpg')
 
     @property
+    def thumbnails_uri(self):
+        """Get video's thumbnails' link."""
+        return url_for(
+            'invenio_records_ui.{0}_export'.format(self.pid.pid_type),
+            pid_value=self.pid.pid_value,
+            format='vtt')
+
+    @property
     def smil_file_object(self):
         data = self.file.dumps()
-        if 'smil' in data:
-            smil_info = self.file.dumps()['smil'][0]
+        if 'playlist' in data:
+            smil_info = data['playlist'][0]
             return ObjectVersion.get(smil_info['bucket_id'], smil_info['key'])
 
 

--- a/cds/modules/previewer/extensions/video.py
+++ b/cds/modules/previewer/extensions/video.py
@@ -50,7 +50,7 @@ class VideoExtension(object):
             file=file,
             video_url=file.uri,
             m3u8_url=getattr(file, 'm3u8_uri', None),
-            thumbnails_url=None,
+            thumbnails_url=getattr(file, 'thumbnails_uri', None),
             poster_url=getattr(file, 'poster_uri', None),
             embed=self.embed,
             css_bundles=['cds_previewer_video_css'],

--- a/cds/modules/records/views.py
+++ b/cds/modules/records/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,7 +21,9 @@
 
 from __future__ import absolute_import, print_function
 import six
+from cds.modules.records.serializers import VTTSerializer
 from flask import Blueprint, current_app, render_template, request
+from flask import make_response
 from werkzeug.utils import import_string
 
 blueprint = Blueprint(
@@ -53,3 +55,11 @@ def records_ui_export(pid, record, template=None, **kwargs):
             data=data,
             format_title=formats[fmt]['title']
         )
+
+
+def records_ui_export_vtt(pid, record, **kwargs):
+    """Export a record as a VTT file."""
+    data = VTTSerializer().serialize(pid, record)
+    response = make_response(data)
+    response.headers['Content-Type'] = 'text/vtt'
+    return response

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ setup(
             # 'cds_xrootd = cds.modules.xrootd:CDSXRootD',
             # FIXME should be move to invenio-webhooks
             'invenio_webhooks = invenio_webhooks:InvenioWebhooks',
+            'cds_iiif = cds.modules.cds_iiif:CDSIIIF',
         ],
         'invenio_base.blueprints': [
             'cds_deposit = cds.modules.deposit.views:blueprint',

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,8 +28,10 @@
 from __future__ import absolute_import, print_function
 
 import os
+import random
 import shutil
 import tempfile
+import uuid
 
 from os.path import dirname, join
 
@@ -463,213 +465,80 @@ def video_record_metadata():
                       'file_video_metadata_extraction': 'SUCCESS'},
             'status': 'draft'
         },
-        "_files": [
-            {
-                "checksum": "md5:1beda6154605f65a922fdc488c987d83",
-                "completed": True,
-                "frame": [
-                    {
-                        "bucket_id": "0692a21c-6864-41cb-8424-b0f83eeb261b",
-                        "checksum": "md5:7b4ba010ee4bd84074208f634fe3a672",
-                        "completed": True,
-                        "key": "frame-1.jpg",
-                        "links": {
-                            "self": "/api/files/0692a21c-6864-41cb-8424-b0f83eeb261b/frame-1.jpg?versionId=7cc97a14-61f3-4902-a3cf-7a22af1859d8"
-                        },
-                        "progress": 100,
-                        "size": 22774,
-                        "tags": {
-                            "master": "f333e846-2620-416d-92e2-8137ed772692",
-                            "type": "frame"
-                        },
-                        "version_id": "7cc97a14-61f3-4902-a3cf-7a22af1859d8"
-                    },
-                    {
-                        "key": "frame-2.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-2.jpg?versionId=8ed2544a-c841-49a5-914b-8619c321c580"
-                        },
-                    },
-                    {
-                        "key": "frame-3.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-3.jpg?versionId=f04969d4-ab5f-4818-9f06-bea0e3843310"
-                        },
-                    },
-                    {
-                        "key": "frame-4.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-4.jpg?versionId=4528d78c-722a-4b70-8caa-42fdd4393857"
-                        },
-                    },
-                    {
-                        "key": "frame-5.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-5.jpg?versionId=13841296-7d58-49fa-b800-69112ae6953d"
-                        },
-                    },
-                    {
-                        "key": "frame-6.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-6.jpg?versionId=1fbc2a8f-dc42-40f5-ab4c-aaff57c1600e"
-                        },
-                    },
-                    {
-                        "key": "frame-7.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-7.jpg?versionId=d7b5d937-ca26-4d34-b8bc-8e70857c3544"
-                        },
-                    },
-                    {
-                        "key": "frame-8.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-8.jpg?versionId=7f765733-cbbd-47c6-bd60-5b98940e86b6"
-                        },
-                    },
-                    {
-                        "key": "frame-9.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-9.jpg?versionId=ecb09ee8-1c31-47da-a5a0-c9e4906faba2"
-                        },
-                    },
-                    {
-                        "key": "frame-10.jpg",
-                        "links": {
-                            "self": "/api/files/d2692fc0-a49d-40b9-824f-42099cb98fd3/frame-10.jpg?versionId=4351274e-3639-4ff9-a75f-fdc7c2efa7a1"
-                        },
-                    },
+        '_files': [
+            dict(
+                context_type='master',
+                media_type='video',
+                content_type='mp4',
+                checksum='md5:1beda6154605f65a922fdc488c987d83',
+                completed=True,
+                key='test.mp4',
+                frame=[
+                    dict(
+                        bucket_id='0692a21c-6864-41cb-8424-b0f83eeb261b',
+                        checksum='md5:7b4ba010ee4bd84074208f634fe3a672',
+                        completed=True,
+                        key='frame-{}.jpg'.format(i),
+                        links=dict(
+                            self=('/api/files/0692a21c-6864-41cb-8424-b0f83eeb'
+                                  '261b/frame-{}.jpg?versionId=7cc97a14-61f3-4'
+                                  '902-a3cf-7a22af1859d8'.format(i))),
+                        progress=100,
+                        size=22774,
+                        tags=dict(
+                            master='f333e846-2620-416d-92e2-8137ed772692',
+                            type='frame',
+                            timestamp=(float(i) / 10) * 60.095
+                        ),
+                        version_id='7cc97a14-61f3-4902-a3cf-7a22af1859d8')
+                    for i in range(11)
                 ],
-                "tags": {
-                    "bit_rate": "11915822",
-                    "height": "2160",
-                    "uri_origin": (
-                        "https://mediaarchive.cern.ch/MediaArchive/"
-                        "Video/Public/Movies/CERN/2016/CERN-MOVIE-2016-06"
-                        "6/CERN-MOVIE-2016-066-001/CERN-MOVIE-2016-066-00"
-                        "1-11872-kbps-4096x2160-audio-128-kbps-stereo.mp4"
-                    ),
-                    "width": "4096",
-                    "duration": "100",
-                },
-                "video": [
-                    {
-                        "checksum": "md5:127efd1d7b090924d6c2e46848987b69",
-                        "completed": True,
-                        "key": (
-                            "CERN-MOVIE-2016-066-001-11872-kbps-"
-                            "4096x2160-audio-128-kbps-stereo[240p].mp4"
-                        ),
-                        "links": {
-                            "self": (
-                                "/api/files/d2692fc0-a49d-40b9-824f-42099c"
-                                "b98fd3/CERN-MOVIE-2016-066-001-11872-kbps"
-                                "-4096x2160-audio-128-kbps-stereo[240p].mp"
-                                "4?versionId=02ff769e-21e0-4a79-93b1-7e82a"
-                                "9e8efe1"
-                            ),
-                        },
-                        "progress": 100,
-                        "size": 4457627,
-                        "tags": {
-                            "_sorenson_job_id":
-                                "1d0ab2fa-e26b-41c1-8fca-45afe2d00b61",
-                            "master":
-                                "9e4ce306-077c-463c-8a0e-b368edcdd7c3",
-                            "preset_quality": "240p",
-                            "type": "video"
-                        },
-                        "version_id":
-                            "02ff769e-21e0-4a79-93b1-7e82a9e8efe1"
-                    },
-                    {
-                        "checksum": "",
-                        "completed": True,
-                        "key": (
-                            "CERN-MOVIE-2016-066-001-11872-kbps-"
-                            "4096x2160-audio-128-kbps-stereo[360p].mp4"
-                        ),
-                        "links": {
-                            "self": (
-                                "/api/files/d2692fc0-a49d-40b9-824f-42099c"
-                                "b98fd3/CERN-MOVIE-2016-066-001-11872-kbps"
-                                "-4096x2160-audio-128-kbps-stereo[360p].mp"
-                                "4?versionId=e5f98169-a041-47d0-ae24-f1734"
-                                "44c1147"
-                            ),
-                        },
-                        "progress": 100,
-                        "size": 0,
-                        "tags": {
-                            "_sorenson_job_id":
-                                "8d6f784c-f20f-45e6-a18c-bb1d186f46b0",
-                            "master":
-                                "9e4ce306-077c-463c-8a0e-b368edcdd7c3",
-                            "preset_quality": "360p",
-                            "type": "video"
-                        },
-                        "version_id":
-                            "e5f98169-a041-47d0-ae24-f173444c1147"
-                    },
-                    {
-                        "checksum": "md5:9999176fd09d9c54ecb56534fae0ff54",
-                        "completed": True,
-                        "key": (
-                            "CERN-MOVIE-2016-066-001-11872-kbps-"
-                            "4096x2160-audio-128-kbps-stereo[480p].mp4"
-                        ),
-                        "links": {
-                            "self": (
-                                "/api/files/d2692fc0-a49d-40b9-824f-42099c"
-                                "b98fd3/CERN-MOVIE-2016-066-001-11872-kbps"
-                                "-4096x2160-audio-128-kbps-stereo[480p].mp"
-                                "4?versionId=92e6ac64-708a-4075-846a-6e385"
-                                "3707a1a"
-                            ),
-                        },
-                        "progress": 100,
-                        "size": 14382281,
-                        "tags": {
-                            "_sorenson_job_id":
-                                "deb59f6a-5836-4936-9d61-06516a045b03",
-                            "master":
-                                "9e4ce306-077c-463c-8a0e-b368edcdd7c3",
-                            "preset_quality": "480p",
-                            "type": "video"
-                        },
-                        "version_id":
-                            "92e6ac64-708a-4075-846a-6e3853707a1a"
-                    },
-                    {
-                        "checksum": "md5:fb3d75b05bce32cca582e69316a97918",
-                        "completed": True,
-                        "key": (
-                            "CERN-MOVIE-2016-066-001-11872-kbps-"
-                            "4096x2160-audio-128-kbps-stereo[720p].mp4"
-                        ),
-                        "links": {
-                            "self": (
-                                "/api/files/d2692fc0-a49d-40b9-824f-42099c"
-                                "b98fd3/CERN-MOVIE-2016-066-001-11872-kbps"
-                                "-4096x2160-audio-128-kbps-stereo[720p].mp"
-                                "4?versionId=15d67ae2-f998-4681-9c26-6770a"
-                                "c0e18c4"
-                            ),
-                        },
-                        "progress": 100,
-                        "size": 26662844,
-                        "tags": {
-                            "_sorenson_job_id":
-                                "6c3d597e-3eed-43eb-b8d0-e773f767d853",
-                            "master":
-                                "9e4ce306-077c-463c-8a0e-b368edcdd7c3",
-                            "preset_quality": "720p",
-                            "type": "video"
-                        },
-                        "version_id":
-                            "15d67ae2-f998-4681-9c26-6770ac0e18c4"
-                    }
-                ]
-            }
+                tags=dict(
+                    bit_rate='11915822',
+                    width='4096',
+                    height='2160',
+                    uri_origin=(
+                        'https://mediaarchive.cern.ch/MediaArchive/'
+                        'Video/Public/Movies/CERN/2016/CERN-MOVIE-2016-06'
+                        '6/CERN-MOVIE-2016-066-001/CERN-MOVIE-2016-066-00'
+                        '1-11872-kbps-4096x2160-audio-128-kbps-stereo.mp4'),
+                    duration='60.095',),
+                subformat=[
+                    dict(
+                        context_type='subformat',
+                        media_type='video',
+                        content_type='mp4',
+                        checksum='md5:{:032d}'.format(random.randint(1, 1000)),
+                        completed=True,
+                        key='CERN-MOVIE-2106-test[{}p]'.format(quality),
+                        links=dict(
+                            self='/api/files/...'),
+                        progress=100,
+                        size=4457627,
+                        tags=dict(
+                            _sorenson_job_id=str(uuid.uuid4()),
+                            master=str(uuid.uuid4()),
+                            preset_quality='{}p'.format(quality),),
+                        version_id=str(uuid.uuid4()),)
+                    for quality in enumerate([240, 360, 480, 720])
+                ],
+                playlist=[
+                    dict(
+                        context_type='playlist',
+                        media_type='text',
+                        content_type='smil',
+                        checksum='md5:{:032d}'.format(random.randint(1, 1000)),
+                        completed=True,
+                        key='test.smil',
+                        links=dict(
+                            self='/api/files/...'),
+                        progress=100,
+                        size=12355,
+                        tags=dict(
+                            master=str(uuid.uuid4())),
+                        version_id=str(uuid.uuid4()),)
+                ],
+            )
         ],
         'contributors': [
             {'name': 'paperone', 'role': 'Director'},

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -154,7 +154,7 @@ def get_tag_count(download=True, metadata=True, frames=True, transcode=True):
     return sum([
         5 if download else 0,
         10 if download and metadata else 0,
-        11 * 3 if frames else 0,
+        3 + 10 * 4 if frames else 0,
         len(get_available_preset_qualities()) * 5 if transcode else 0,
     ])
 

--- a/tests/unit/test_ffmpeg.py
+++ b/tests/unit/test_ffmpeg.py
@@ -74,9 +74,16 @@ def test_ffprobe(video):
     (90, 100, 2),
 ])
 def test_frames(video, start, end, gap):
-    """Test frame extarction."""
+    """Test frame extraction."""
+    # Convert percentages to values
+    duration = float(ff_probe(video, 'duration'))
+    time_step = duration * gap / 100
+    start_time = duration * start / 100
+    end_time = duration * (end + 1) / 100  # end inclusive
+
     tmp = tempfile.mkdtemp(dir=dirname(__file__))
-    ff_frames(video, start, end, gap, join(tmp, 'img%d.jpg'))
+    ff_frames(video, start_time, end_time, time_step,
+              duration, join(tmp, 'img%d.jpg'))
     file_no = len([f for f in listdir(tmp) if isfile(join(tmp, f))])
     assert file_no == floor(((end - start) / gap) + 1)
     shutil.rmtree(tmp)

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -106,4 +106,4 @@ def test_fixture_videos(app, script_info, db, location):
             # Has 5 frames
             assert len(files['frame']) == 5
             # Has 3 subformats
-            assert len(files['video']) == 3
+            assert len(files['subformat']) == 3

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Test cds package."""
+"""Test records."""
 
 from __future__ import absolute_import, print_function
 
@@ -93,7 +93,7 @@ def test_records_ui_export(app, project_published, video_record_metadata):
 
         res = client.get(url_valid_vtt)
         assert res.status_code == 200
-        assert get_pre(res.data).startswith('WEBVTT') is True
+        assert 'WEBVTT' in res.data.decode('utf-8')
 
         res = client.get(url_valid_json)
         assert res.status_code == 200
@@ -162,8 +162,8 @@ def test_records_rest(api_app, users, video_record_metadata, es,
             assert child.attrib["height"] == '2160'
 
         for i in range(4):
-            src = \
-                video_record_metadata['_files'][0]['video'][i]['links']['self']
+            subformat = video_record_metadata['_files'][0]['subformat']
+            src = subformat[i]['links']['self']
             assert root[1][0][i].attrib['src'] == 'mp4:{}'.format(src)
 
         # try get vtt

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Test cds package."""
+"""Test serializers."""
 
 from __future__ import absolute_import, print_function
 
@@ -42,12 +42,13 @@ def test_smil_serializer(video_record_metadata):
     assert len(root[1][0]) == 4
     for child in root[1][0]:
         assert child.tag == 'video'
-        assert child.attrib["system-bitrate"] == '11915822'
-        assert child.attrib["width"] == '4096'
-        assert child.attrib["height"] == '2160'
+        assert child.attrib['system-bitrate'] == '11915822'
+        assert child.attrib['width'] == '4096'
+        assert child.attrib['height'] == '2160'
 
     for i in range(4):
-        src = video_record_metadata['_files'][0]['video'][i]['links']['self']
+        subformat = video_record_metadata['_files'][0]['subformat'][i]
+        src = subformat['links']['self']
         assert root[1][0][i].attrib['src'] == 'mp4:{}'.format(src)
 
 
@@ -59,6 +60,6 @@ def test_vtt_serializer(video_record_metadata):
         if i == 9:
             end_expected = VTT.time_format(float(
                 video_record_metadata['_files'][0]['tags']['duration']))
-            assert data[i]["end_time"] == end_expected
+            assert data[i]['end_time'] == end_expected
         else:
-            assert data[i]["end_time"] == data[i + 1]["start_time"]
+            assert data[i]['end_time'] == data[i + 1]['start_time']

--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -200,6 +200,7 @@ def test_video_extract_frames(app, db, bucket, video):
     """Test extract frames from video."""
     obj = ObjectVersion.create(
         bucket=bucket, key='video.mp4', stream=open(video, 'rb'))
+    ObjectVersionTag.create(obj, 'duration', '60.095000')
     version_id = str(obj.version_id)
     db.session.commit()
 
@@ -219,10 +220,10 @@ def test_video_extract_frames(app, db, bucket, video):
     ExtractFramesTask().clean(version_id=version_id)
 
     assert ObjectVersion.query.count() == 1  # master file
-    frames = ObjectVersion.query.join(ObjectVersion.tags).filter(
+    frames_and_gif = ObjectVersion.query.join(ObjectVersion.tags).filter(
         ObjectVersionTag.key == 'master',
         ObjectVersionTag.value == version_id).all()
-    assert len(frames) == 0
+    assert len(frames_and_gif) == 0
 
 
 def test_task_failure(celery_not_fail_on_eager_app, db, cds_depid, bucket):


### PR DESCRIPTION

 * Configured THEO player to display thumbnails on hover. (closes #415)

 * Separate endpoint for exporting VTT file. ()

 * Thumbnails provided as resized frames by IIIF.

 * FFmpeg frame extraction now takes absolute time values instead of
   percentages.

 * Added `timestamp` tag on frame files.

 * Registered CDSIIIF extension on `invenio_apps` too.

 * Adds tests for coverage.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>