### PR TITLE
deposit: embedded video preview

### DIFF
--- a/cds/modules/previewer/templates/cds_previewer/previewer_video.html
+++ b/cds/modules/previewer/templates/cds_previewer/previewer_video.html
@@ -47,11 +47,6 @@
 {% block panel %}
   <video class="cds-previewer-video-player"
     src="{{file_url}}"
-    {% if file.record._files %}
-      poster="{{ 'http://placeholdit.imgix.net/~text?txtsize=144&txt=Video%20Preview%20Unavailable&w=1920&h=1080' }}"
-    {% else %}
-      poster="//placeholdit.imgix.net/~text?txtsize=144&txt=Video%20Preview%20Unavailable&w=1920&h=1080"
-    {% endif %}
     controls="controls">
   </video>
 {% endblock %}


### PR DESCRIPTION
* Show preview image of embedded videos in deposits. (closes #439)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>