### PR TITLE
deposit: task status in deposit list

### DIFF
--- a/cds/modules/deposit/bundles.py
+++ b/cds/modules/deposit/bundles.py
@@ -71,8 +71,9 @@ js_jquery = NpmBundle(
     output='gen/cds.deposit.jquery.deposit.%(version)s.js',
 )
 
-js_cds_deposit = NpmBundle(
+js_deposit_common = Bundle(
     'js/cds_deposit/avc/avc.module.js',
+    'js/cds_deposit/avc/filters/orderTasks.js',
     'js/cds_deposit/avc/filters/progressClass.js',
     'js/cds_deposit/avc/filters/progressIcon.js',
     'js/cds_deposit/avc/filters/toInt.js',
@@ -80,10 +81,15 @@ js_cds_deposit = NpmBundle(
     'js/cds_deposit/avc/providers/depositSSEEvents.js',
     'js/cds_deposit/avc/providers/depositStatuses.js',
     'js/cds_deposit/avc/providers/inheritedProperties.js',
-    'js/cds_deposit/avc/providers/errorRepresentations.js',
+    'js/cds_deposit/avc/providers/taskRepresentations.js',
     'js/cds_deposit/avc/providers/stateReducer.js',
     'js/cds_deposit/avc/providers/typeReducer.js',
     'js/cds_deposit/avc/providers/urlBuilder.js',
+    output='gen/cds.deposit.common.%(version)s.js'
+)
+
+js_cds_deposit = NpmBundle(
+    js_deposit_common,
     'js/cds_deposit/avc/factories/states.js',
     'js/cds_deposit/avc/components/cdsActions.js',
     'js/cds_deposit/avc/components/cdsDeposit.js',

--- a/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
@@ -4,7 +4,7 @@ function cdsDepositsConfig(
   depositSSEEventsProvider,
   depositStatusesProvider,
   inheritedPropertiesProvider,
-  errorRepresentationsProvider,
+  taskRepresentationsProvider,
   urlBuilderProvider,
   typeReducerProvider
 ) {
@@ -44,11 +44,11 @@ function cdsDepositsConfig(
     'contributors'
   ]);
 
-  errorRepresentationsProvider.setValues({
-    file_download: 'Video file download error',
-    file_transcode: 'Video transcoding error',
-    file_video_extract_frames: 'Video frame extraction error',
-    file_video_metadata_extraction: 'Video metadata extraction error'
+  taskRepresentationsProvider.setValues({
+    file_download: 'Video file download',
+    file_transcode: 'Video transcoding',
+    file_video_extract_frames: 'Video frame extraction',
+    file_video_metadata_extraction: 'Video metadata extraction'
   });
 
   // Initialize url builder
@@ -75,7 +75,7 @@ cdsDepositsConfig.$inject = [
   'depositSSEEventsProvider',
   'depositStatusesProvider',
   'inheritedPropertiesProvider',
-  'errorRepresentationsProvider',
+  'taskRepresentationsProvider',
   'urlBuilderProvider',
   'typeReducerProvider',
 ];
@@ -92,13 +92,13 @@ angular.module('cdsDeposit.modules', [
   'cdsDeposit.providers',
   'cdsDeposit.factories',
   'cdsDeposit.components',
-]);
+]).config(cdsDepositsConfig);
 
 angular
   .module('cdsDeposit.filters')
-  .filter('errorRepr', function(errorRepresentations) {
+  .filter('taskRepr', function(taskRepresentations) {
     return function(input) {
-      return errorRepresentations[input] || input;
+      return taskRepresentations[input] || input;
     };
   });
 
@@ -120,5 +120,4 @@ angular
     'monospaced.elastic',
     'invenioFiles.filters',
     'afkl.lazyImage',
-  ])
-  .config(cdsDepositsConfig);
+  ]);

--- a/cds/modules/deposit/static/js/cds_deposit/avc/filters/orderTasks.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/filters/orderTasks.js
@@ -1,0 +1,15 @@
+function orderTasks(depositStates) {
+  return function(input) {
+    var ordered = new Map;
+    if (input) {
+      depositStates.forEach(function (task) {
+        if (input.hasOwnProperty(task)) {
+          ordered[task] = input[task];
+        }
+      });
+    }
+    return ordered;
+  };
+}
+
+angular.module("cdsDeposit.filters").filter("orderTasks", orderTasks);

--- a/cds/modules/deposit/static/js/cds_deposit/avc/providers/taskRepresentations.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/providers/taskRepresentations.js
@@ -1,4 +1,4 @@
-function errorRepresentations() {
+function taskRepresentations() {
   var representations = {};
   return {
     setValues: function(values) {
@@ -11,4 +11,4 @@ function errorRepresentations() {
 }
 
 angular.module('cdsDeposit.providers')
-  .provider('errorRepresentations', errorRepresentations);
+  .provider('taskRepresentations', taskRepresentations);

--- a/cds/modules/deposit/static/templates/cds_deposit/deposits.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/deposits.html
@@ -67,17 +67,8 @@
               <p><strong>{{ $ctrl.master.metadata.title.title || 'No project title.' }}</strong></p>
             </div>
             <ul class="list-inline text-left">
-              <li>
-                <i class="fa fa-fw {{ $ctrl.aggregatedState['file_download'] | progressIcon }} {{ $ctrl.aggregatedState['file_download'] | progressClass }}"></i> File download
-              </li>
-              <li>
-                <i class="fa fa-fw {{ $ctrl.aggregatedState['file_video_metadata_extraction'] | progressIcon }} {{ $ctrl.aggregatedState['file_video_metadata_extraction'] | progressClass }}"></i> Extract metadata
-              </li>
-              <li>
-                <i class="fa fa-fw {{ $ctrl.aggregatedState['file_video_extract_frames'] | progressIcon }} {{ $ctrl.aggregatedState['file_video_extract_frames'] | progressClass }}"></i> Extract frames
-              </li>
-              <li>
-                <i class="fa fa-fw {{ $ctrl.aggregatedState['file_transcode'] | progressIcon}} {{ $ctrl.aggregatedState['file_transcode'] | progressClass}}"></i> File transcode
+              <li ng-repeat="(task, status) in ($ctrl.aggregatedState | orderTasks)">
+                <i class="fa fa-fw {{ status | progressIcon }} {{ status | progressClass }}"></i> {{ task | taskRepr }}
               </li>
             </ul>
           </div>

--- a/cds/modules/deposit/static/templates/cds_deposit/search/results.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/search/results.html
@@ -21,6 +21,13 @@
         <p class="list-group-item-text text-muted">
           <small>Created on {{ record.created | date:'medium' }}, last updated on {{ record.updated | date:'medium' }}</small>
         </p>
+        <p>
+          <ul class="list-inline text-left">
+            <li class="small" ng-repeat="(task, status) in (record.metadata._deposit.state | orderTasks)">
+              <i class="fa fa-fw {{ status | progressIcon }} {{ status | progressClass }}"></i> {{ task | taskRepr }}
+            </li>
+          </ul>
+        </p>
       </div>
       <div class="clearfix"></div>
     </a>

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
@@ -31,7 +31,7 @@
               <!-- FAILURE -->
               <div ng-show="$ctrl.cdsDepositCtrl.displayFailure()">
                 <div class="alert alert-danger" ng-repeat="status in $ctrl.cdsDepositCtrl.stateQueue.FAILURE">
-                    <strong>{{ $ctrl.cdsDepositCtrl.stateReporter[status].message | errorRepr }}</strong>
+                    <strong>Error: {{ $ctrl.cdsDepositCtrl.stateReporter[status].message | taskRepr }}</strong>
                 </div>
               </div>
               <!-- PENDING -->

--- a/cds/modules/deposit/templates/cds_deposit/index.html
+++ b/cds/modules/deposit/templates/cds_deposit/index.html
@@ -30,7 +30,9 @@
 
 {%- block javascript %}
   {{ super() }}
-  {% assets "cds_search_ui_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+  {% assets "cds_search_ui_js", "cds_deposit_common_js" %}
+    <script src="{{ ASSET_URL }}"></script>
+  {% endassets %}
 {%- endblock javascript %}
 
 {%- block body_inner %}

--- a/cds/modules/theme/bundles.py
+++ b/cds/modules/theme/bundles.py
@@ -58,6 +58,7 @@ js = NpmBundle(
         'node_modules/ng-dialog/js/ngDialog.js',
         'node_modules/clipboard/dist/clipboard.js',
         'node_modules/ngclipboard/dist/ngclipboard.js',
+        'node_modules/underscore/underscore.js',
         'node_modules/d3/d3.js',
         'node_modules/angular-loading-bar/build/loading-bar.js',
         'js/cds/module.js',
@@ -66,6 +67,8 @@ js = NpmBundle(
         filters='jsmin',
     ),
     depends=(
+        'js/cds_deposit/avc/filters/progressClass.js',
+        'js/cds_deposit/avc/filters/progressIcon.js',
         'js/*.js',
         'js/cds/*.js',
         'node_modules/invenio-search-js/dist/*.js',
@@ -77,6 +80,7 @@ js = NpmBundle(
         'ng-dialog': '~0.6.0',
         'clipboard': '~1.5.16',
         'ngclipboard': '~1.1.1',
+        'underscore': '~1.8.3',
     }
 )
 """Default JavaScript bundle."""

--- a/cds/modules/theme/static/js/main.js
+++ b/cds/modules/theme/static/js/main.js
@@ -24,7 +24,7 @@
 // Bootstrap modules
 angular.element(document).ready(function() {
   angular.bootstrap(
-    document.getElementById("invenio-search"), ['cds', 'angular-loading-bar', 'ngDialog', 'invenioSearch']
+    document.getElementById("invenio-search"), ['cds', 'angular-loading-bar', 'ngDialog', 'invenioSearch', 'cdsDeposit.modules']
   );
   angular.bootstrap(
     document.getElementById("cds-featured-video"), [ 'cds', 'invenioSearch']

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,8 @@ setup(
         'invenio_assets.bundles': [
             'cds_deposit_jquery_js = cds.modules.deposit.bundles:js_jquery',
             'cds_deposit_js = cds.modules.deposit.bundles:js_deposit',
+            'cds_deposit_common_js = '
+            'cds.modules.deposit.bundles:js_deposit_common',
             'cds_previewer_theoplayer_css = '
             'cds.modules.previewer.bundles:theoplayer_css',
             'cds_previewer_theoplayer_js = '


### PR DESCRIPTION
* Displays the status of the workflow tasks in the deposit list for each
  deposit. (closes #464)

* Moves the Angular deposit module that contains filters, providers,
  components and factories to a different file.

* Changes the errorRepresentations provider to the more generic
  taskRepresentations.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>