### PR TITLE
deposit: permission denied message

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -68,7 +68,11 @@ function cdsDepositsCtrl(
             that.children.push(response.data);
           }, function error(response) {});
         });
-      }, function error(response) {});
+      }, function error(response) {
+        if (response.status === 403) {
+          that.permissionDenied = true;
+        }
+      });
     }
   };
 

--- a/cds/modules/deposit/static/templates/cds_deposit/deposits.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/deposits.html
@@ -1,4 +1,4 @@
-<div ng-if="!$ctrl.initialized">
+<div ng-if="!$ctrl.initialized && !$ctrl.permissionDenied">
   <div class="container">
     <div class="row">
   <div class="col-md-12">
@@ -167,4 +167,12 @@
       </div>
     </div>
   </cds-deposit>
+</div>
+
+<div ng-if="$ctrl.permissionDenied">
+  <div class="container">
+    <div class="row">
+      <h1>Permission denied</h1>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
* Displays a "Permission denied" message if a user tries to access a
  deposit without having permission to. (closes #474)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>