### PR TITLE
tests: remove unused depid fixture

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -220,20 +220,6 @@ def u_email(db, users):
 
 
 @pytest.fixture()
-def depid(app, users, db):
-    """New deposit with files."""
-    record = {
-        'title': {'title': 'fuu'}
-    }
-    with app.test_request_context():
-        login_user(User.query.get(users[0]))
-        deposit = Deposit.create(record)
-        deposit.commit()
-        db.session.commit()
-    return deposit['_deposit']['id']
-
-
-@pytest.fixture()
 def cds_depid(api_app, users, db, bucket, deposit_metadata):
     """New deposit with files."""
     record = {'title': {'title': 'fuu'}}


### PR DESCRIPTION
Removes the `depid` fixture - it doesn't seem to be used anywhere (tests use the `cds_depid` instead) and simply trying to use this fixture in a test, gives an error:

```
    def do_execute(self, cursor, statement, parameters, context=None):
>       cursor.execute(statement, parameters)
E       psycopg2.IntegrityError: duplicate key value violates unique constraint "pk_sequencegenerator_template"
E       DETAIL:  Key (name)=(project-v1_0_0) already exists.

../../.virtualenvs/cdslabs3p3/lib/python3.5/site-packages/sqlalchemy/engine/default.py:470: IntegrityError
```