### PR TITLE
webhooks: avoid raise in resolution not found

### DIFF
--- a/cds/modules/webhooks/tasks.py
+++ b/cds/modules/webhooks/tasks.py
@@ -494,7 +494,7 @@ class TranscodeVideoTask(AVCTask):
                 self.update_state(
                     state=REVOKED,
                     meta={'payload': {}, 'message': str(e)})
-                raise
+                return
 
             # Set revoke handler, in case of an abrupt execution halt.
             self.set_revoke_handler(partial(stop_encoding, job_id))


### PR DESCRIPTION
* Avoids to raise a resolution exception on transcoding task.
  (closes #477)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>