### PR TITLE
record: external embed URL in record page

### DIFF
--- a/cds/modules/records/static/templates/cds_records/video/share.html
+++ b/cds/modules/records/static/templates/cds_records/video/share.html
@@ -40,7 +40,7 @@
 <div class="cds-detail-video-embed">
   <h4>Embed</h4>
   <div class="input-group">
-    <input type="text" class="form-control" value="http://localhost:5000{{ '' | previewIframe: record.recid:record._files[0].key }}">
+    <input type="text" class="form-control" value="{{ '' | previewIframe: record.recid:record._files[0].key:true }}">
     <span class="input-group-btn">
       <button class="btn btn-default" data-clipboard-text="nice_link" type="button"><i class="fa fa-copy"></i></button>
     </span>

--- a/cds/modules/theme/static/js/cds/module.js
+++ b/cds/modules/theme/static/js/cds/module.js
@@ -22,9 +22,12 @@
 */
 
 var app = angular.module('cds', ['ngclipboard']);
-app.filter('previewIframe', ['$sce', function($sce) {
-  return function(text, id, key) {
+app.filter('previewIframe', ['$sce', '$window', function($sce, $window) {
+  return function(text, id, key, external) {
     var _url = '/record/' + id + '/preview/' + key;
+    if (external) {
+      _url = $window.location.origin + _url;
+    }
     return $sce.trustAsResourceUrl(_url);
   };
 }]);


### PR DESCRIPTION
* Changes the embed share URL in the record detail page to point to the
  external embedded. (fixes #468)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>