### PR TITLE
deposit: dump file's type information

### DIFF
--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -32,6 +32,7 @@ import uuid
 import datetime
 import itertools
 from contextlib import contextmanager
+from os.path import splitext
 
 import arrow
 from celery import states
@@ -96,15 +97,24 @@ class CDSFileObject(FileObject):
     def dumps(self):
         """Create a dump of the metadata associated to the record."""
         def _dumps(obj):
+            tags = obj.get_tags()
+            # File information
+            content_type = splitext(obj.key)[1][1:].lower()
+            context_type = tags.pop('context_type', '')
+            media_type = tags.pop('media_type', '')
             return {
                 'key': obj.key,
                 'bucket_id': str(obj.bucket_id),
                 'version_id': str(obj.version_id),
                 'checksum': obj.file.checksum if obj.file else '',
                 'size': obj.file.size if obj.file else 0,
+                'file_id': str(obj.file_id),
                 'completed': True,
                 'progress': 100,
-                'tags': obj.get_tags(),
+                'content_type': content_type,
+                'context_type': context_type,
+                'media_type': media_type,
+                'tags': tags,
                 'links': {
                     'self': (
                         current_app.config['DEPOSIT_FILES_API'] +

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -152,10 +152,10 @@ def get_object_count(download=True, frames=True, transcode=True):
 def get_tag_count(download=True, metadata=True, frames=True, transcode=True):
     """Get number of ObjectVersionTags, based on executed tasks."""
     return sum([
-        3 if download else 0,
+        5 if download else 0,
         10 if download and metadata else 0,
-        11 * 2 if frames else 0,
-        len(get_available_preset_qualities()) * 4 if transcode else 0,
+        11 * 3 if frames else 0,
+        len(get_available_preset_qualities()) * 5 if transcode else 0,
     ])
 
 

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -129,6 +129,7 @@ def test_download_receiver(api_app, db, bucket, api_project, access_token,
                         'tags': {
                             u'uri_origin': u'http://example.com/test.pdf',
                             u'_event_id': str(tags['_event_id']),
+                            u'context_type': u'master',
                         },
                         'deposit_id': video_1_depid,
                         'percentage': percentage,
@@ -741,7 +742,7 @@ def test_avc_workflow_receiver_clean_video_transcode(
         assert 'extracted_metadata' in records[0].json['_deposit']
 
         assert ObjectVersion.query.count() == get_object_count() - i
-        assert ObjectVersionTag.query.count() == get_tag_count() - (i * 4)
+        assert ObjectVersionTag.query.count() == get_tag_count() - (i * 5)
 
     assert ObjectVersion.query.count() == get_object_count(transcode=False)
     assert ObjectVersionTag.query.count() == get_tag_count(transcode=False)
@@ -757,7 +758,7 @@ def test_avc_workflow_receiver_clean_video_transcode(
         assert ObjectVersion.query.count() == get_object_count(
             transcode=False) + i
         assert ObjectVersionTag.query.count() == get_tag_count(
-            transcode=False) + (i * 4)
+            transcode=False) + (i * 5)
 
     assert ObjectVersion.query.count() == get_object_count()
     assert ObjectVersionTag.query.count() == get_tag_count()

--- a/tests/unit/test_webhook_views.py
+++ b/tests/unit/test_webhook_views.py
@@ -110,7 +110,7 @@ def check_video_transcode_delete(api_app, event_id, access_token,
         assert resp.status_code == 204
 
     assert ObjectVersion.query.count() == get_object_count() - 1
-    assert ObjectVersionTag.query.count() == get_tag_count() - 4
+    assert ObjectVersionTag.query.count() == get_tag_count() - 5
 
     # check extracted metadata is there
     records = RecordMetadata.query.all()
@@ -144,7 +144,7 @@ def check_video_transcode_delete(api_app, event_id, access_token,
         assert resp.status_code == 204
 
     assert ObjectVersion.query.count() == get_object_count() - 2
-    assert ObjectVersionTag.query.count() == get_tag_count() - 8
+    assert ObjectVersionTag.query.count() == get_tag_count() - 10
 
     # check extracted metadata is there
     records = RecordMetadata.query.all()


### PR DESCRIPTION
 * A file dump now contains information regarding its `media`, `content`
   and `context` type. (closes #431)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>