### PR TITLE
mappings: addition of license

### DIFF
--- a/cds/modules/deposit/mappings/deposits/records/project-v1.0.0.json
+++ b/cds/modules/deposit/mappings/deposits/records/project-v1.0.0.json
@@ -4,7 +4,18 @@
             "numeric_detection": true,
             "properties": {
                 "license": {
-                    "type": "string"
+                    "type": "object",
+                    "properties": {
+                        "license": {
+                          "type": "string"
+                        },
+                        "material": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                    }
                 },
                 "_access": {
                     "type": "object",

--- a/cds/modules/deposit/mappings/deposits/records/video-v1.0.0.json
+++ b/cds/modules/deposit/mappings/deposits/records/video-v1.0.0.json
@@ -144,7 +144,18 @@
                     "type": "double"
                 },
                 "license": {
-                    "type": "string"
+                    "type": "object",
+                    "properties": {
+                        "license": {
+                          "type": "string"
+                        },
+                        "material": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        }
+                    }
                 },
                 "translations": {
                   "type": "object",


### PR DESCRIPTION
* Adds `license` to deposit mappings. (closes #497)

Signed-off-by: Harris Tzovanakis <me@drjova.com>