### PR TITLE
deposit: dynamic transcoding presets

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -139,8 +139,7 @@ function cdsDepositCtrl(
     this.initializeStateReported = function() {
       that.stateReporter = {};
       that.presets_finished = [];
-      // FIXME: Get them from the Webhooks
-      that.presets = [ '360p', '720p', '480p', '240p', '1080p', '1024p' ];
+      that.presets = [];
       depositStates.map(function(state) {
         that.stateReporter[state] = {
           status: state,

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
@@ -84,7 +84,10 @@ function cdsUploaderCtrl($scope, $q, Upload, $http, $timeout, urlBuilder) {
             _subpromise = d.promise;
           }
           _subpromise.then(
-            function success() {;
+            function success(avcResponse) {
+              if (avcResponse) {
+                that.cdsDepositCtrl.presets = avcResponse.data.presets;
+              }
               promise.resolve(response);
             }
           );
@@ -131,6 +134,7 @@ function cdsUploaderCtrl($scope, $q, Upload, $http, $timeout, urlBuilder) {
     $http(args)
       .then(
         function success(response) {
+          that.cdsDepositCtrl.presets = response.data.presets;
         },
         function error(response) {
           promise.reject(response);


### PR DESCRIPTION
* Fetch transcoding presets from AVC workflow response.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>