### PR TITLE
access: same access rights for deposit and record

### DIFF
--- a/cds/modules/deposit/search.py
+++ b/cds/modules/deposit/search.py
@@ -24,32 +24,11 @@
 
 """Configuration for deposit search."""
 
-from elasticsearch_dsl import Q, TermsFacet
-from flask import has_request_context
-from flask_login import current_user
-from invenio_deposit.permissions import admin_permission_factory
+from elasticsearch_dsl import TermsFacet
 from invenio_search import RecordsSearch
 from invenio_search.api import DefaultFilter
 
-
-def deposits_filter():
-    """Filter list of deposits.
-
-    Permit to the user to see all if:
-
-    * The user is an admin (see
-        func:`invenio_deposit.permissions:admin_permission_factory`).
-
-    * It's called outside of a request.
-
-    Otherwise, it filters out any deposit where user is not the owner.
-    """
-    if not has_request_context() or admin_permission_factory().can():
-        return Q()
-    else:
-        return Q(
-            'match', **{'_deposit.owners': getattr(current_user, 'id', 0)}
-        )
+from ..records.search import cern_filter
 
 
 class ProjectSearch(RecordsSearch):
@@ -64,4 +43,4 @@ class ProjectSearch(RecordsSearch):
         facets = {
             'status': TermsFacet(field='_deposit.status'),
         }
-        default_filter = DefaultFilter(deposits_filter)
+        default_filter = DefaultFilter(cern_filter)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -233,7 +233,7 @@ def cds_depid(api_app, users, db, bucket, deposit_metadata):
     with api_app.test_request_context():
         login_user(User.query.get(users[0]))
         deposit = Project.create(record)
-        deposit['_deposit']['owners'].append('test-egroup@cern.ch')
+        deposit['_access'] = {'update': ['test-egroup@cern.ch']}
         deposit.commit()
         db.session.commit()
     return deposit['_deposit']['id']

--- a/tests/unit/test_access_search.py
+++ b/tests/unit/test_access_search.py
@@ -37,14 +37,16 @@ def mock_provides(needs):
     g.identity.provides = needs
 
 
-def test_es_filter():
+def test_es_filter(users):
     """Test query filter based on CERN groups."""
     mock_provides([UserNeed('test@test.ch'), RoleNeed('groupX')])
     assert CERNRecordsSearch().to_dict()['query']['bool']['filter'] == [
         {'bool': {'filter': [{'bool': {
             'should': [
                 {'missing': {'field': '_access.read'}},
-                {'terms': {'_access.read': ['test@test.ch', 'groupX']}}
+                {'terms': {'_access.read': ['test@test.ch', 'groupX']}},
+                {'terms': {'_access.update': ['test@test.ch', 'groupX']}},
+                {'match': {'_deposit.created_by': 0}}
             ]
         }}]}}
     ]

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -544,7 +544,7 @@ def test_project_permissions(es, location, deposit_metadata, users):
     user = User.query.get(users[0])
     login_user(user)
     assert not has_update_permission(user, deposit)
-    deposit['_deposit']['owners'].append(user.id)
+    deposit['_access'] = {'update': [user.id]}
     assert has_update_permission(user, deposit)
 
 


### PR DESCRIPTION
* Drops usage of `_deposit.owners` in favor of `_access.update` for
  deposit keeping all access rights definitions in the same key.
  `_deposit.created+by` is still used. (addresses #518)