### PR TITLE
deposit: correct sort index

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -357,9 +357,13 @@ RECORDS_REST_SORT_OPTIONS = dict(
 )
 
 # Default sort for records REST API.
-RECORDS_REST_DEFAULT_SORT = dict(
-    records=dict(query='bestmatch'),
-)
+RECORDS_REST_DEFAULT_SORT = {
+    'records': dict(query='bestmatch'),
+    'deposits-records-project-v1.0.0': dict(
+        query='bestmatch',
+        noquery='mostrecent'
+    )
+}
 
 # Defined facets for records REST API.
 RECORDS_REST_FACETS = dict(
@@ -443,6 +447,25 @@ RECORD_VIDEOS_FACETS = {
             'type': terms_filter('type'),
         },
     }
+}
+
+# Deposit search index.
+DEPOSIT_UI_SEARCH_INDEX = 'deposits-records-project-v1.0.0'
+
+# Options for sorting deposits.
+DEPOSIT_REST_SORT_OPTIONS = {
+    'deposits-records-project-v1.0.0': dict(
+        bestmatch=dict(
+            fields=['-_score'],
+            title='Best match',
+            default_order='asc',
+            order=2
+        ),
+        mostrecent=dict(
+            fields=['-_updated'],
+            title='Most recent',
+            default_order='asc', order=1
+        )),
 }
 
 # Update facets and sort options with deposit options

--- a/cds/modules/deposit/templates/cds_deposit/index.html
+++ b/cds/modules/deposit/templates/cds_deposit/index.html
@@ -122,6 +122,7 @@
                   sort-key="sort"
                   available-options='{{ sort_options|format_sortoptions|safe }}'
                   template="{{ url_for('static', filename='templates/invenio_deposit/selectbox.html') }}"
+                  default-sort-by="{{ config.get('RECORDS_REST_DEFAULT_SORT', {}).get(config.get('DEPOSIT_UI_SEARCH_INDEX'), {}).get('noquery') }}"
                   >
                 </invenio-search-select-box>
                 {%- endblock search_sort_select %}


### PR DESCRIPTION
* Changes the elasticsearch index used for deposit sorting. (closes #548)

* Selects a default "sort by" option if one isn't selected.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>