### PR TITLE
deposit: partial marshmallow loaders

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -686,7 +686,9 @@ DEPOSIT_REST_ENDPOINTS = dict(
         default_endpoint_prefix=False,
         record_class='cds.modules.deposit.api:Project',
         record_loaders={
-            'application/json': 'cds.modules.deposit.loaders:project_loader'
+            'application/json': 'cds.modules.deposit.loaders:project_loader',
+            'application/vnd.project.partial+json':
+                'cds.modules.deposit.loaders:partial_project_loader',
         },
         files_serializers={
             'application/json': ('invenio_deposit.serializers'
@@ -731,7 +733,9 @@ DEPOSIT_REST_ENDPOINTS = dict(
         default_endpoint_prefix=False,
         record_class='cds.modules.deposit.api:Video',
         record_loaders={
-            'application/json': 'cds.modules.deposit.loaders:video_loader'
+            'application/json': 'cds.modules.deposit.loaders:video_loader',
+            'application/vnd.video.partial+json':
+                'cds.modules.deposit.loaders:partial_video_loader'
         },
         files_serializers={
             'application/json': ('invenio_deposit.serializers'

--- a/cds/modules/deposit/bundles.py
+++ b/cds/modules/deposit/bundles.py
@@ -82,6 +82,7 @@ js_deposit_common = Bundle(
     'js/cds_deposit/avc/providers/depositStates.js',
     'js/cds_deposit/avc/providers/depositSSEEvents.js',
     'js/cds_deposit/avc/providers/depositStatuses.js',
+    'js/cds_deposit/avc/providers/depositActions.js',
     'js/cds_deposit/avc/providers/inheritedProperties.js',
     'js/cds_deposit/avc/providers/taskRepresentations.js',
     'js/cds_deposit/avc/providers/stateReducer.js',

--- a/cds/modules/deposit/loaders/__init__.py
+++ b/cds/modules/deposit/loaders/__init__.py
@@ -26,7 +26,10 @@ from cds.modules.records.serializers.schemas.project import ProjectSchema
 from cds.modules.records.serializers.schemas.video import VideoSchema
 
 
-# Loader for project schema.
+# Loaders for project schema.
 project_loader = marshmallow_loader(ProjectSchema)
-# Loader for video schema.
+partial_project_loader = marshmallow_loader(ProjectSchema, partial=True)
+
+# Loaders for video schema.
 video_loader = marshmallow_loader(VideoSchema)
+partial_video_loader = marshmallow_loader(VideoSchema, partial=True)

--- a/cds/modules/deposit/loaders/loader.py
+++ b/cds/modules/deposit/loaders/loader.py
@@ -27,9 +27,9 @@ from flask import request
 from invenio_rest.errors import RESTValidationError
 
 
-def marshmallow_loader(schema_class):
+def marshmallow_loader(schema_class, partial=False):
     def schema_loader():
-        result = schema_class().load(request.get_json())
+        result = schema_class(partial=partial).load(request.get_json())
         if result.errors:
             raise MarshmallowErrors(result.errors)
         return request.get_json()

--- a/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
@@ -3,6 +3,7 @@ function cdsDepositsConfig(
   depositStatesProvider,
   depositSSEEventsProvider,
   depositStatusesProvider,
+  depositActions,
   inheritedPropertiesProvider,
   taskRepresentationsProvider,
   urlBuilderProvider,
@@ -37,6 +38,9 @@ function cdsDepositsConfig(
     SUCCESS: 'DEPOSIT_STATE/SUCCESS',
     REVOKED: 'DEPOSIT_STATE/REVOKED',
   });
+
+  // Deposit actions' information
+  depositActions.setValues(['project', 'video'])
 
   inheritedPropertiesProvider.setValues([
     'title.title',
@@ -74,6 +78,7 @@ cdsDepositsConfig.$inject = [
   'depositStatesProvider',
   'depositSSEEventsProvider',
   'depositStatusesProvider',
+  'depositActionsProvider',
   'inheritedPropertiesProvider',
   'taskRepresentationsProvider',
   'urlBuilderProvider',

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsActions.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsActions.js
@@ -7,12 +7,12 @@ function cdsActionsCtrl($scope) {
       that.cdsDepositCtrl.loading = false;
     };
 
-    this.actionHandler = function(type, method) {
+    this.actionHandler = function(action) {
       // Start loading
       $scope.$emit('cds.deposit.loading.start');
       that.cdsDepositCtrl.loading = true;
       return that.cdsDepositCtrl
-        .makeSingleAction(type, method)
+        .makeSingleAction(action)
         .then(
           that.cdsDepositCtrl.onSuccessAction,
           that.cdsDepositCtrl.onErrorAction
@@ -34,7 +34,7 @@ function cdsActionsCtrl($scope) {
     };
 
     this.deleteDeposit = function() {
-      that.actionHandler('self', 'DELETE').then(function() {
+      that.actionHandler('DELETE').then(function() {
         var children = that.cdsDepositCtrl.cdsDepositsCtrl.children;
         for (var i in children) {
           if (children[i].metadata._deposit.id == that.cdsDepositCtrl.id) {

--- a/cds/modules/deposit/static/js/cds_deposit/avc/factories/states.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/factories/states.js
@@ -1,10 +1,19 @@
 function cdsAPI($q, $http) {
-  function action(url, method, payload) {
-    return $http({
+
+  function action(url, method, payload, mimetype) {
+    requestConfig = {
       url: url,
       method: method,
       data: payload
-    });
+    };
+
+    if (mimetype) {
+      requestConfig.headers = {
+        'Content-Type': mimetype
+      }
+    }
+
+    return $http(requestConfig);
   }
 
   function chainedActions(promises) {

--- a/cds/modules/deposit/static/js/cds_deposit/avc/providers/depositActions.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/providers/depositActions.js
@@ -1,0 +1,66 @@
+function depositActions() {
+  var actions = {};
+  return {
+    setValues: function(depositTypes, extraActions) {
+      actions = depositTypes.reduce(function(obj, depositType) {
+        obj[depositType] = Object.assign({
+          CREATE: {
+            method: 'POST',
+            link: 'self',
+            mimetype: 'application/vnd.' + depositType + '.partial+json',
+            preprocess: sanitizeData
+          },
+          SAVE_PARTIAL: {
+            method: 'PUT',
+            link: 'self',
+            mimetype: 'application/vnd.' + depositType + '.partial+json',
+            preprocess: sanitizeData
+          },
+          SAVE: {
+            method: 'PUT',
+            link: 'self'
+          },
+          EDIT: {
+            method: 'POST',
+            link: 'edit'
+          },
+          PUBLISH: {
+            method: 'POST',
+            link: 'publish'
+          },
+          DELETE: {
+            method: 'DELETE',
+            link: 'self'
+          }
+        }, extraActions || {})
+        return obj
+      }, {})
+    },
+    $get: function() {
+      return actions;
+    }
+  };
+}
+
+function isPopulated(val) {
+  return val !== null && val !== undefined &&
+    !(val.constructor === Object && _.isEmpty(val));
+}
+
+function sanitizeData(payload) {
+    if (_.isArray(payload)) {
+      return payload.map(sanitizeData).filter(isPopulated);
+    } else if (_.isObject(payload)) {
+      return _.chain(payload)
+              .mapObject(sanitizeData)
+              .omit(function(value) {
+                return !isPopulated(value);
+              })
+              .value();
+    } else {
+      return payload;
+    }
+}
+
+angular.module('cdsDeposit.providers')
+  .provider('depositActions', depositActions);

--- a/cds/modules/deposit/static/json/cds_deposit/forms/project.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/project.json
@@ -3,7 +3,8 @@
     "leftColumn": [
       {
         "title": "Name",
-        "key": "title.title"
+        "key": "title.title",
+        "required": false
       },
       {
         "type": "template",
@@ -14,7 +15,7 @@
         "format": "yyyy-MM-dd",
         "description": "Required. Format: YYYY-MM-DD. In case your upload was already published elsewhere, please use the date of first publication.",
         "fa_cls": "fa-calendar",
-        "required": true
+        "required": false
       },
       {
         "type": "section",
@@ -41,9 +42,9 @@
               "removePlugins": "elementspath",
               "removeButtons": ""
             },
-            "required": true,
             "description": "Required.",
-            "minLength": 1
+            "minLength": 1,
+            "required": false
           }
         ]
       }
@@ -51,7 +52,6 @@
     "rightColumn": [
       {
         "key": "category",
-        "required": true,
         "placeholder": "Category",
         "title": "Category",
         "type": "strapselect",
@@ -61,11 +61,11 @@
         "options": {
           "url": "/api/categories",
           "asyncCallback": "$ctrl.autocompleteCategories"
-        }
+        },
+        "required": false
       },
       {
         "key": "type",
-        "required": true,
         "placeholder": "Type",
         "title": "Type",
         "type": "strapselect",
@@ -76,7 +76,8 @@
           "filterTriggers": ["model.category"],
           "filter" : "item.category == model.category",
           "asyncCallback": "$ctrl.autocompleteType"
-        }
+        },
+        "required": false
       },
       {
         "type": "array",

--- a/cds/modules/deposit/static/json/cds_deposit/forms/video.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/video.json
@@ -29,9 +29,9 @@
             "removePlugins": "elementspath",
             "removeButtons": ""
           },
-          "required": true,
           "description": "Required.",
-          "minLength": 1
+          "minLength": 1,
+          "required": false
         }
       ]
     },
@@ -129,7 +129,7 @@
       "format": "yyyy-MM-dd",
       "description": "Required. Format: YYYY-MM-DD. In case your upload was already published elsewhere, please use the date of first publication.",
       "fa_cls": "fa-calendar",
-      "required": true
+      "required": false
     },
     {
       "type": "array",

--- a/cds/modules/deposit/static/templates/cds_deposit/types/project/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/project/actions.html
@@ -3,7 +3,7 @@
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published"'
     ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-default btn-sm"
-    ng-click="$ctrl.actionHandler('self', 'PUT')">
+    ng-click="$ctrl.actionHandler('SAVE_PARTIAL')">
   Save
   </button>
 
@@ -11,7 +11,7 @@
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published"'
     ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
     class="btn btn-primary btn-sm"
-    ng-click="$ctrl.actionMultipleHandler([['self', 'PUT'], ['publish', 'POST']], '/deposit')">
+    ng-click="$ctrl.actionMultipleHandler(['SAVE', 'PUBLISH'], '/deposit')">
   Publish
   </button>
 
@@ -19,7 +19,7 @@
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status== "draft"'
     ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-success btn-sm"
-    ng-click="$ctrl.actionMultipleHandler([['edit', 'POST'], ['self', 'PUT']], '/deposit')">
+    ng-click="$ctrl.actionMultipleHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit
   </button>
 </div>

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
@@ -3,7 +3,7 @@
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.depositFormModel.$pristine'
     ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-default btn-sm"
-    ng-click="$ctrl.actionHandler('self', 'PUT')">
+    ng-click="$ctrl.actionHandler('SAVE_PARTIAL')">
   Save
   </button>
 
@@ -11,7 +11,7 @@
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || !$ctrl.cdsDepositCtrl.depositFormModel.$pristine'
     ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
     class="btn btn-primary btn-sm"
-    ng-click="$ctrl.actionMultipleHandler([['self', 'PUT'], ['publish', 'POST']], '/deposit')">
+    ng-click="$ctrl.actionMultipleHandler(['SAVE', 'PUBLISH'], '/deposit')">
   Publish
   </button>
 
@@ -19,7 +19,7 @@
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status== "draft"'
     ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-warning btn-sm"
-    ng-click="$ctrl.actionMultipleHandler([['edit', 'POST'], ['self', 'PUT']], '/deposit')">
+    ng-click="$ctrl.actionMultipleHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit
   </button>
 </div>

--- a/cds/modules/records/serializers/schemas/project.py
+++ b/cds/modules/records/serializers/schemas/project.py
@@ -76,7 +76,5 @@ class ProjectSchema(StrictKeysSchema):
     title = fields.Nested(TitleSchema)
     videos = fields.Nested(ProjectVideoSchema, many=True)
     translations = fields.Nested(TranslationsSchema, many=True)
-    category = fields.Str()
-    type = fields.Str()
     report_number = fields.Nested(ReportNumberSchema, many=False)
     publication_date = fields.Str()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -626,6 +626,20 @@ def json_headers(app):
 
 
 @pytest.fixture()
+def json_partial_project_headers(app):
+    """JSON headers for partial project deposits."""
+    return [('Content-Type', 'application/vnd.project.partial+json'),
+            ('Accept', 'application/json')]
+
+
+@pytest.fixture()
+def json_partial_video_headers(app):
+    """JSON headers for partial video deposits."""
+    return [('Content-Type', 'application/vnd.video.partial+json'),
+            ('Accept', 'application/json')]
+
+
+@pytest.fixture()
 def smil_headers(app):
     """SMIL headers."""
     return [('Content-Type', 'application/smil'),

--- a/tests/unit/test_deposit.py
+++ b/tests/unit/test_deposit.py
@@ -38,13 +38,15 @@ from invenio_accounts.testutils import login_user_via_session
 from invenio_files_rest.models import FileInstance, ObjectVersionTag, Bucket
 from invenio_files_rest.models import ObjectVersion
 
-from cds.modules.deposit.loaders import project_loader, video_loader
+from cds.modules.deposit.loaders import partial_project_loader, \
+    partial_video_loader, project_loader, video_loader
 from cds.modules.deposit.loaders.loader import MarshmallowErrors
 
 
 def test_deposit_link_factory_has_bucket(
-        app, db, es, users, location, cds_jsonresolver, json_headers,
-        deposit_rest, project_deposit_metadata):
+        app, db, es, users, location, cds_jsonresolver, deposit_rest,
+        json_headers, json_partial_project_headers, json_partial_video_headers,
+        video_deposit_metadata, project_deposit_metadata):
     """Test bucket link factory retrieval of a bucket."""
     with app.test_client() as client:
         login_user_via_session(client, email=User.query.get(users[0]).email)
@@ -52,7 +54,8 @@ def test_deposit_link_factory_has_bucket(
         # Test links for project
         res = client.post(
             url_for('invenio_deposit_rest.project_list'),
-            data=json.dumps(project_deposit_metadata), headers=json_headers)
+            data=json.dumps(project_deposit_metadata),
+            headers=json_partial_project_headers)
         assert res.status_code == 201
         data = json.loads(res.data.decode('utf-8'))
         links = data['links']
@@ -62,15 +65,14 @@ def test_deposit_link_factory_has_bucket(
             .format(
                 host=request.host,
                 scheme=request.scheme,
-                pid_value=pid,
-        )
+                pid_value=pid)
 
         # Test links for videos
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
             data=json.dumps({
                 '_project_id': pid,
-            }), headers=json_headers)
+            }), headers=json_partial_video_headers)
         assert res.status_code == 201
         data = json.loads(res.data.decode('utf-8'))
         links = data['links']
@@ -80,8 +82,7 @@ def test_deposit_link_factory_has_bucket(
             .format(
                 host=request.host,
                 scheme=request.scheme,
-                pid_value=pid,
-        )
+                pid_value=pid)
 
 
 def test_links_filter(es, location, deposit_metadata):

--- a/tests/unit/test_project_rest.py
+++ b/tests/unit/test_project_rest.py
@@ -39,10 +39,11 @@ from invenio_indexer.api import RecordIndexer
 from helpers import prepare_videos_for_publish
 
 
-def test_simple_workflow(app, db, es, users, location, cds_jsonresolver,
-                         data_file_1, data_file_2, json_headers, deposit_rest,
-                         project_deposit_metadata, video_deposit_metadata,
-                         deposit_metadata):
+def test_simple_workflow(
+        app, db, es, users, location, cds_jsonresolver, deposit_rest,
+        data_file_1, data_file_2,
+        json_headers, json_partial_project_headers, json_partial_video_headers,
+        deposit_metadata, project_deposit_metadata, video_deposit_metadata):
     """Test project simple workflow."""
     def check_connection(videos, project):
         """check project <---> video connection."""
@@ -61,7 +62,8 @@ def test_simple_workflow(app, db, es, users, location, cds_jsonresolver,
         # [[ CREATE NEW PROJECT ]]
         res = client.post(
             url_for('invenio_deposit_rest.project_list'),
-            data=json.dumps(project_deposit_metadata), headers=json_headers)
+            data=json.dumps(project_deposit_metadata),
+            headers=json_partial_project_headers)
 
         # check returned value
         assert res.status_code == 201
@@ -84,7 +86,8 @@ def test_simple_workflow(app, db, es, users, location, cds_jsonresolver,
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         # check returned value
         assert res.status_code == 201
@@ -119,7 +122,8 @@ def test_simple_workflow(app, db, es, users, location, cds_jsonresolver,
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         # check returned value
         assert res.status_code == 201
@@ -305,8 +309,9 @@ def test_simple_workflow(app, db, es, users, location, cds_jsonresolver,
 
 
 def test_publish_project_check_indexed(
-        app, db, es, users, location, cds_jsonresolver, json_headers,
-        deposit_rest, video_deposit_metadata, project_deposit_metadata):
+        app, db, es, users, location, cds_jsonresolver, deposit_rest,
+        json_headers, json_partial_project_headers, json_partial_video_headers,
+        video_deposit_metadata, project_deposit_metadata):
     """Test create a project and check project and videos are indexed."""
     with app.test_client() as client:
         login_user_via_session(client, email=User.query.get(users[0]).email)
@@ -314,7 +319,8 @@ def test_publish_project_check_indexed(
         # [[ CREATE NEW PROJECT ]]
         res = client.post(
             url_for('invenio_deposit_rest.project_list'),
-            data=json.dumps(project_deposit_metadata), headers=json_headers)
+            data=json.dumps(project_deposit_metadata),
+            headers=json_partial_project_headers)
 
         assert res.status_code == 201
         project_dict = json.loads(res.data.decode('utf-8'))
@@ -325,7 +331,8 @@ def test_publish_project_check_indexed(
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         # check returned value
         assert res.status_code == 201
@@ -337,7 +344,8 @@ def test_publish_project_check_indexed(
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         # check returned value
         assert res.status_code == 201
@@ -361,7 +369,7 @@ def test_publish_project_check_indexed(
                 as mock_indexer:
             # [[ PUBLISH THE PROJECT ]]
             prepare_videos_for_publish([video_1, video_2])
-            res = client.post(
+            client.post(
                 url_for('invenio_deposit_rest.project_actions',
                         pid_value=project['_deposit']['id'], action='publish'),
                 headers=json_headers)

--- a/tests/unit/test_video_rest.py
+++ b/tests/unit/test_video_rest.py
@@ -47,9 +47,9 @@ from cds.modules.deposit.tasks import datacite_register
             RecordIdProvider.create)
 @mock.patch('invenio_pidstore.providers.datacite.DataCiteMDSClient')
 def test_video_publish_registering_the_datacite(
-        datacite_mock, app, deposit_metadata, users, json_headers,
-        deposit_rest, video_deposit_metadata, project_deposit_metadata,
-        location, cds_jsonresolver):
+        datacite_mock, app, users, deposit_rest, location, cds_jsonresolver,
+        json_headers, json_partial_project_headers, json_partial_video_headers,
+        deposit_metadata, video_deposit_metadata, project_deposit_metadata):
     """Test video publish registering the datacite."""
     # test: enable datacite registration
     app.config['DEPOSIT_DATACITE_MINTING_ENABLED'] = True
@@ -61,7 +61,7 @@ def test_video_publish_registering_the_datacite(
         res = client.post(
             url_for('invenio_deposit_rest.project_list'),
             data=json.dumps(project_deposit_metadata),
-            headers=json_headers)
+            headers=json_partial_project_headers)
 
         assert res.status_code == 201
         project_dict = json.loads(res.data.decode('utf-8'))
@@ -72,7 +72,8 @@ def test_video_publish_registering_the_datacite(
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         assert res.status_code == 201
         video_1_dict = json.loads(res.data.decode('utf-8'))
@@ -106,9 +107,9 @@ def test_video_publish_registering_the_datacite(
             RecordIdProvider.create)
 @mock.patch('invenio_pidstore.providers.datacite.DataCiteMDSClient')
 def test_video_publish_registering_the_datacite_if_fail(
-        datacite_mock, app, deposit_metadata, users, json_headers,
-        deposit_rest, video_deposit_metadata, project_deposit_metadata,
-        location, cds_jsonresolver):
+        datacite_mock, app, users, deposit_rest, location, cds_jsonresolver,
+        json_headers, json_partial_project_headers, json_partial_video_headers,
+        deposit_metadata, video_deposit_metadata, project_deposit_metadata):
     """Test video publish registering the datacite."""
     # test: enable datacite registration
     app.config['DEPOSIT_DATACITE_MINTING_ENABLED'] = True
@@ -120,7 +121,7 @@ def test_video_publish_registering_the_datacite_if_fail(
         res = client.post(
             url_for('invenio_deposit_rest.project_list'),
             data=json.dumps(project_deposit_metadata),
-            headers=json_headers)
+            headers=json_partial_project_headers)
 
         assert res.status_code == 201
         project_dict = json.loads(res.data.decode('utf-8'))
@@ -131,7 +132,8 @@ def test_video_publish_registering_the_datacite_if_fail(
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         assert res.status_code == 201
         video_1_dict = json.loads(res.data.decode('utf-8'))
@@ -160,9 +162,9 @@ def test_video_publish_registering_the_datacite_if_fail(
             RecordIdProvider.create)
 @mock.patch('invenio_pidstore.providers.datacite.DataCiteMDSClient')
 def test_video_publish_registering_the_datacite_not_local(
-        datacite_mock, app, deposit_metadata, users, json_headers,
-        deposit_rest, video_deposit_metadata, project_deposit_metadata,
-        location, cds_jsonresolver):
+        datacite_mock, app, users, deposit_rest, location, cds_jsonresolver,
+        json_headers, json_partial_project_headers, json_partial_video_headers,
+        deposit_metadata, video_deposit_metadata, project_deposit_metadata):
     """Test video publish registering the datacite not local."""
     # test: enable datacite registration
     app.config['DEPOSIT_DATACITE_MINTING_ENABLED'] = True
@@ -174,7 +176,7 @@ def test_video_publish_registering_the_datacite_not_local(
         res = client.post(
             url_for('invenio_deposit_rest.project_list'),
             data=json.dumps(project_deposit_metadata),
-            headers=json_headers)
+            headers=json_partial_project_headers)
 
         assert res.status_code == 201
         project_dict = json.loads(res.data.decode('utf-8'))
@@ -185,7 +187,8 @@ def test_video_publish_registering_the_datacite_not_local(
             _project_id=project_dict['metadata']['_deposit']['id'])
         res = client.post(
             url_for('invenio_deposit_rest.video_list'),
-            data=json.dumps(video_metadata), headers=json_headers)
+            data=json.dumps(video_metadata),
+            headers=json_partial_video_headers)
 
         assert res.status_code == 201
         video_1_dict = json.loads(res.data.decode('utf-8'))


### PR DESCRIPTION
deposit: partial marshmallow loaders
* Adds partial marshmallow loaders, which are used when a specific
  mimetype is present. (closes #324, closes #436)

* Adds payload sanitization on the front-end (i.e. removes empty
  values in objects/arrays before sending payload).

* Removes required fields from Schema Form.

* Tests will be added on later PR (with data model updates).

Co-Authored-By: Nikos Filippakis <nikolaos.filippakis@cern.ch>
Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>