### PR TITLE
deposit: save during AVC workflow

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
@@ -60,16 +60,6 @@ function cdsFormCtrl($scope, $http, $q, schemaFormDecorators) {
   }
 
   this.autocompleteAuthors = function(options, query) {
-    // If the query string is empty and there's already a value set on the
-    // model, this means that the form was just loaded and is trying to
-    // display this value.
-    // This also happens when the user clicks on a suggestion or on the
-    // suggestion field. In this case, return the previous suggestions.
-    if (query === '' && that.lastAuthorSuggestions) {
-      var defer = $q.defer();
-      defer.resolve(that.lastAuthorSuggestions);
-      return defer.promise;
-    }
     if (query) {
       // Parse the url parameters
       return $http.get(options.url, {
@@ -88,6 +78,15 @@ function cdsFormCtrl($scope, $http, $q, schemaFormDecorators) {
         };
         return that.lastAuthorSuggestions;
       });
+    } else {
+      // If the query string is empty and there's already a value set on the
+      // model, this means that the form was just loaded and is trying to
+      // display this value.
+      // This also happens when the user clicks on a suggestion or on the
+      // suggestion field. In this case, return the previous suggestions.
+      var defer = $q.defer();
+      defer.resolve(that.lastAuthorSuggestions || { data: [] });
+      return defer.promise;
     }
   };
 

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsUploader.js
@@ -317,8 +317,6 @@ function cdsUploaderCtrl($scope, $q, Upload, $http, $timeout, urlBuilder) {
     this.upload = function() {
       if (that.queue.length > 0) {
         // FIXME: LOADING
-        // Start loading
-        $scope.$emit('cds.deposit.loading.start');
         // Start local loading
         that.cdsDepositCtrl.loading = true;
         that.loading = true;
@@ -333,7 +331,6 @@ function cdsUploaderCtrl($scope, $q, Upload, $http, $timeout, urlBuilder) {
           ).finally(
             function done() {
               // FIXME: LOADING
-              $scope.$emit('cds.deposit.loading.stop');
               that.cdsDepositCtrl.loading = false;
               that.loading = false;
             }


### PR DESCRIPTION
* Allow saving of project metadata while processing video files.
  (fixes #542)

* Fix javascript console error introduced by #590.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>