### PR TITLE
deposit: non-video file upload

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -78,7 +78,7 @@ function cdsDepositsCtrl(
 
   this.addMaster = function(deposit, files) {
     if (!this.initialized) {
-      if (deposit.metadata._files === undefined) {
+      if (_.isEmpty(deposit.metadata._files)) {
         deposit.metadata._files = files || [];
       }
       this.master = deposit;
@@ -145,7 +145,7 @@ function cdsDepositsCtrl(
   };
 
   this.filterOutFiles = function(files) {
-    // Logic to separated
+    // Logic to separate
     var _files = { project: [], videos: {}, videoFiles: {} };
     angular.forEach(files, function(file, index) {
       var match = that.isVideoFile(file.name);


### PR DESCRIPTION
* Fixes issue with non-video files not being attached to the project,\
  when they are provided on the first uploader. (closes #593)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>