### PR TITLE
deposit: save button enabled on licenses changes

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -489,8 +489,11 @@ function cdsDepositCtrl(
     that.postSuccessProcess(response);
     // Inform the parents
     $scope.$emit('cds.deposit.success', response);
-    // Make the form pristine again
+    // Make the forms pristine again
     that.depositFormModel.$setPristine();
+    if (that.depositFormModelB) {
+      that.depositFormModelB.$setPristine();
+    }
   };
 
   this.onErrorAction = function(response) {

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
@@ -1,6 +1,6 @@
 <div class="text-right">
   <button
-    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.depositFormModel.$pristine'
+    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || ($ctrl.cdsDepositCtrl.depositFormModel.$pristine && $ctrl.cdsDepositCtrl.depositFormModelB.$pristine)'
     ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-default btn-sm"
     ng-click="$ctrl.actionHandler('SAVE_PARTIAL')">
@@ -8,8 +8,8 @@
   </button>
 
   <button
-    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || !$ctrl.cdsDepositCtrl.depositFormModel.$pristine'
-    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
+    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || !($ctrl.cdsDepositCtrl.depositFormModel.$pristine && $ctrl.cdsDepositCtrl.depositFormModelB.$pristine)'
+    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.depositFormModelB.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
     class="btn btn-primary btn-sm"
     ng-click="$ctrl.actionMultipleHandler(['SAVE', 'PUBLISH'], '/deposit')">
   Publish
@@ -17,7 +17,7 @@
 
   <button
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status== "draft"'
-    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
+    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.depositFormModelB.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-warning btn-sm"
     ng-click="$ctrl.actionMultipleHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit


### PR DESCRIPTION
* Enables the 'save' button when a change is made in the 'licenses' tab.
  (fixes #486)

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>