### PR TITLE
deposit: request headers for partial-validation

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -294,7 +294,7 @@ function cdsDepositsCtrl(
   };
 
   this.makeAction = function(url, depositType, action, payload) {
-    var { method, mimetype, preprocess } = depositActions[depositType][action];
+    var { method, headers, preprocess } = depositActions[depositType][action];
     if (preprocess) {
       payload = preprocess(payload);
     }

--- a/cds/modules/deposit/static/js/cds_deposit/avc/factories/states.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/factories/states.js
@@ -1,16 +1,14 @@
 function cdsAPI($q, $http) {
 
-  function action(url, method, payload, mimetype) {
+  function action(url, method, payload, headers) {
     requestConfig = {
       url: url,
       method: method,
       data: payload
     };
 
-    if (mimetype) {
-      requestConfig.headers = {
-        'Content-Type': mimetype
-      }
+    if (headers) {
+      requestConfig.headers = headers
     }
 
     return $http(requestConfig);

--- a/cds/modules/deposit/static/js/cds_deposit/avc/providers/depositActions.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/providers/depositActions.js
@@ -3,17 +3,24 @@ function depositActions() {
   return {
     setValues: function(depositTypes, extraActions) {
       actions = depositTypes.reduce(function(obj, depositType) {
+        mimetype = 'application/vnd.' + depositType + '.partial+json',
         obj[depositType] = Object.assign({
           CREATE: {
             method: 'POST',
             link: 'self',
-            mimetype: 'application/vnd.' + depositType + '.partial+json',
+            headers: {
+                'Content-Type': mimetype,
+                'Accept': mimetype
+            },
             preprocess: sanitizeData
           },
           SAVE_PARTIAL: {
             method: 'PUT',
             link: 'self',
-            mimetype: 'application/vnd.' + depositType + '.partial+json',
+            headers: {
+                'Content-Type': mimetype,
+                'Accept': mimetype
+            },
             preprocess: sanitizeData
           },
           SAVE: {


### PR DESCRIPTION
* Adds the proper mimetype to the `Accept-Type` header, in addition to
  `Content-Type`. (closes #607)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>