### PR TITLE
deposit: proper schema form statuses

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -12,6 +12,9 @@ function cdsDepositCtrl(
   typeReducer
 ) {
   var that = this;
+
+  this.depositFormModels = [];
+
   // The Upload Queue
   this.filesQueue = [];
 
@@ -490,7 +493,7 @@ function cdsDepositCtrl(
     // Inform the parents
     $scope.$emit('cds.deposit.success', response);
     // Make the form pristine again
-    that.depositFormModel.$setPristine();
+    _.invoke(that.depositFormModels, '$setPristine');
   };
 
   this.onErrorAction = function(response) {
@@ -499,6 +502,20 @@ function cdsDepositCtrl(
     // Inform the parents
     $scope.$emit('cds.deposit.error', response);
   };
+
+  // Form status
+  this.isPristine = function() {
+    return that.depositFormModels.every(_.property('$pristine'))
+  }
+
+  this.isDirty = function() {
+    return that.depositFormModels.some(_.property('$dirty'))
+  }
+
+  this.isInvalid = function() {
+    return that.depositFormModels.some(_.property('$invalid'))
+  }
+
 }
 
 cdsDepositCtrl.$inject = [
@@ -528,7 +545,6 @@ cdsDepositCtrl.$inject = [
  * @attr {String} schema - The URI for the deposit type schema.
  * @attr {Object} links - The deposit action links (i.e. ``self``).
  * @attr {Object} record - The record metadata.
- * @attr {Object} depositFormModel - The angular-schema-form model to be used.
  * @example
  *  Example:
  *  <cds-deposit
@@ -537,7 +553,6 @@ cdsDepositCtrl.$inject = [
  *   update-record-after-success="true"
  *   schema="{{ $ctrl.masterSchema }}"
  *   record="$ctrl.master.metadata"
- *   deposit-form-model="$ctrl.depositForms[0]"
  *  ></cds-deposit>
  */
 function cdsDeposit() {
@@ -554,8 +569,6 @@ function cdsDeposit() {
       schema: '@',
       record: '=',
       links: '=',
-      // The form model
-      depositFormModel: '=?',
     },
     require: { cdsDepositsCtrl: '^cdsDeposits' },
     controller: cdsDepositCtrl,

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -14,8 +14,6 @@ function cdsDepositsCtrl(
   var that = this;
   this.edit = false;
 
-  // The deposit forms
-  this.depositForms = [];
   // The master deposit
   this.master = {};
   // The children deposit

--- a/cds/modules/deposit/static/templates/cds_deposit/deposits.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/deposits.html
@@ -57,7 +57,6 @@
       update-record-after-success="true"
       schema="{{ $ctrl.masterSchema }}"
       record="$ctrl.master.metadata"
-      deposit-form-model="$ctrl.depositForms[0]"
     >
     <div ng-class="{'status-fix-top': !$ctrl.isOnTop}" class="cds-deposit-avc-overall-status mb-20 mt--20">
       <div class="container">
@@ -99,7 +98,6 @@
               links="child.links"
               schema="{{ $ctrl.childrenSchema }}"
               record="child.metadata"
-              deposit-form-model="$ctrl.depositForms[$index + 1]"
             >
               <div class="panel panel-default">
                 <div class="panel-heading">

--- a/cds/modules/deposit/static/templates/cds_deposit/types/project/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/project/actions.html
@@ -1,6 +1,6 @@
 <div class="text-right">
   <button
-    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published"'
+    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.isPristine()'
     ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-default btn-sm"
     ng-click="$ctrl.actionHandler('SAVE_PARTIAL')">
@@ -8,8 +8,8 @@
   </button>
 
   <button
-    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published"'
-    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
+    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.isDirty()'
+    ng-disabled="$ctrl.cdsDepositCtrl.isInvalid() || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
     class="btn btn-primary btn-sm"
     ng-click="$ctrl.actionMultipleHandler(['SAVE', 'PUBLISH'], '/deposit')">
   Publish
@@ -17,7 +17,7 @@
 
   <button
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status== "draft"'
-    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
+    ng-disabled="$ctrl.cdsDepositCtrl.isInvalid() || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-success btn-sm"
     ng-click="$ctrl.actionMultipleHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit

--- a/cds/modules/deposit/static/templates/cds_deposit/types/project/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/project/form.html
@@ -36,7 +36,7 @@
             <div class="row">
               <div class="col-sm-6">
                 <form
-                  name="$ctrl.cdsDepositCtrl.depositFormModel"
+                  name="$ctrl.cdsDepositCtrl.depositFormModels[0]"
                   class="form-horizontal"
                   sf-schema="$ctrl.cdsDepositCtrl.schema"
                   sf-form="$ctrl.form.basic.leftColumn"
@@ -46,7 +46,7 @@
               </div>
               <div class="col-sm-6">
                 <form
-                  name="$ctrl.cdsDepositCtrl.depositFormModel"
+                  name="$ctrl.cdsDepositCtrl.depositFormModels[1]"
                   class="form-horizontal"
                   sf-schema="$ctrl.cdsDepositCtrl.schema"
                   sf-form="$ctrl.form.basic.rightColumn"
@@ -60,7 +60,7 @@
             <div class="row">
               <div class="col-sm-12">
                 <form
-                  name="$ctrl.cdsDepositCtrl.depositFormModel"
+                  name="$ctrl.cdsDepositCtrl.depositFormModels[2]"
                   class="form-horizontal"
                   sf-schema="$ctrl.cdsDepositCtrl.schema"
                   sf-form="$ctrl.form.licenses"
@@ -74,7 +74,7 @@
             <div class="row">
               <div class="col-sm-12">
                 <form
-                  name="$ctrl.cdsDepositCtrl.depositFormModel"
+                  name="$ctrl.cdsDepositCtrl.depositFormModels[3]"
                   class="form-horizontal"
                   sf-schema="$ctrl.cdsDepositCtrl.schema"
                   sf-form="$ctrl.form.translations"
@@ -88,7 +88,7 @@
             <div class="row">
               <div class="col-sm-12">
                 <form
-                  name="$ctrl.cdsDepositCtrl.depositFormModel"
+                  name="$ctrl.cdsDepositCtrl.depositFormModels[4]"
                   class="form-horizontal"
                   sf-schema="$ctrl.cdsDepositCtrl.schema"
                   sf-form="$ctrl.form.access"

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/actions.html
@@ -1,6 +1,6 @@
 <div class="text-right">
   <button
-    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.depositFormModel.$pristine'
+    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.isPristine()'
     ng-disabled="$ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-default btn-sm"
     ng-click="$ctrl.actionHandler('SAVE_PARTIAL')">
@@ -8,8 +8,8 @@
   </button>
 
   <button
-    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || !$ctrl.cdsDepositCtrl.depositFormModel.$pristine'
-    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
+    ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status == "published" || $ctrl.cdsDepositCtrl.isDirty()'
+    ng-disabled="$ctrl.cdsDepositCtrl.isInvalid() || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading || $ctrl.cdsDepositCtrl.depositStatusCurrent === $ctrl.cdsDepositCtrl.depositStatuses.FAILURE"
     class="btn btn-primary btn-sm"
     ng-click="$ctrl.actionMultipleHandler(['SAVE', 'PUBLISH'], '/deposit')">
   Publish
@@ -17,7 +17,7 @@
 
   <button
     ng-hide='$ctrl.cdsDepositCtrl.record._deposit.status== "draft"'
-    ng-disabled="$ctrl.cdsDepositCtrl.depositFormModel.$invalid || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
+    ng-disabled="$ctrl.cdsDepositCtrl.isInvalid() || $ctrl.cdsDepositCtrl.cdsDepositsCtrl.loading"
     class="btn btn-warning btn-sm"
     ng-click="$ctrl.actionMultipleHandler(['EDIT', 'SAVE_PARTIAL'], '/deposit')">
   Edit

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
@@ -79,30 +79,29 @@
                 </li>
               </ul>
               <!-- Tab panes -->
-              <div class="tab-content cds-tab-content pa-20 ">
+              <div class="tab-content cds-tab-content pa-20">
                 <div ng-show="active=='metadata'" role="tabpanel" ng-class="{active: active=='metadata'}" class="tab-pane">
                   <form
-                    name="$ctrl.cdsDepositCtrl.depositFormModel"
+                    name="$ctrl.cdsDepositCtrl.depositFormModels[0]"
                     class="form-horizontal"
                     sf-schema="$ctrl.cdsDepositCtrl.schema"
                     sf-form="$ctrl.form.basic"
                     sf-model="$ctrl.cdsDepositCtrl.record"
-                    sf-options="{formDefaults: { disableSuccessState: true, feedback: false, onChange: '$ctrl.removeValidationMessage(modelValue,form)', ngModelOptions: { updateOn: 'default blur', allowInvalid: true} } }"
-                    ></form>
-
+                    sf-options="{formDefaults: { disableSuccessState: true, feedback: false, onChange: '$ctrl.removeValidationMessage(modelValue,form)', ngModelOptions: { updateOn: 'default blur', allowInvalid: true} } }">
+                  </form>
                 </div>
                 <div ng-show="active=='files'" role="tabpanel" ng-class="{active: active=='files'}"  class="tab-pane">
                   <div ng-transclude></div>
                 </div>
                 <div ng-show="active=='licenses'" role="tabpanel" ng-class="{active: active=='licenses'}"  class="tab-pane">
                   <form
-                    name="$ctrl.cdsDepositCtrl.depositFormModelB"
+                    name="$ctrl.cdsDepositCtrl.depositFormModels[1]"
                     class="form-horizontal"
                     sf-schema="$ctrl.cdsDepositCtrl.schema"
                     sf-form="$ctrl.form.licenses"
                     sf-model="$ctrl.cdsDepositCtrl.record"
-                    sf-options="{formDefaults: { disableSuccessState: true, feedback: false, onChange: '$ctrl.removeValidationMessage(modelValue,form)', ngModelOptions: { updateOn: 'default blur', allowInvalid: true} } }"
-                    ></form>
+                    sf-options="{formDefaults: { disableSuccessState: true, feedback: false, onChange: '$ctrl.removeValidationMessage(modelValue,form)', ngModelOptions: { updateOn: 'default blur', allowInvalid: true} } }">
+                  </form>
                 </div>
                 <div ng-show="active=='debug'" role="tabpanel" ng-class="{active: active=='debug'}"  class="tab-pane">
 


### PR DESCRIPTION
* Cleans up handling of a deposit's schema form status. (#closes #486)

* NOTE Every individual form should use a different form model
  (i.e. different indices in the `depositFormModels` array)

Co-Authored-By: Nikos Filippakis <nikolaos.filippakis@cern.ch>
Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>