### PR TITLE
deposit: autocompletion from extracted metadata

### DIFF
--- a/cds/modules/deposit/bundles.py
+++ b/cds/modules/deposit/bundles.py
@@ -102,10 +102,12 @@ js_cds_deposit = NpmBundle(
     'js/cds_deposit/avc/components/cdsUploader.js',
     'js/cds_deposit/avc/components/cdsRemoteUploader.js',
     'node_modules/angular-lazy-image/release/lazy-image.js',
+    'node_modules/angular-local-storage/dist/angular-local-storage.js',
     npm={
         'angular-schema-form': '~0.8.13',
         'angular-schema-form-bootstrap': '~0.2.0',
         'angular-lazy-image': '~0.3.2',
+        'angular-local-storage': '~0.5.2',
         'objectpath': '~1.2.1',
         'tv4': '~1.2.7',
     }

--- a/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/avc.module.js
@@ -7,13 +7,17 @@ function cdsDepositsConfig(
   inheritedPropertiesProvider,
   taskRepresentationsProvider,
   urlBuilderProvider,
-  typeReducerProvider
+  typeReducerProvider,
+  localStorageServiceProvider
 ) {
   $locationProvider.html5Mode({
     enabled: true,
     requireBase: false,
     rewriteLinks: false,
   });
+
+  // Local storage configuration
+  localStorageServiceProvider.setPrefix('cdsDeposit');
 
   var mainStatuses = [
     'file_download',
@@ -86,6 +90,7 @@ cdsDepositsConfig.$inject = [
   'taskRepresentationsProvider',
   'urlBuilderProvider',
   'typeReducerProvider',
+  'localStorageServiceProvider',
 ];
 
 // Register modules
@@ -100,6 +105,7 @@ angular.module('cdsDeposit.modules', [
   'cdsDeposit.providers',
   'cdsDeposit.factories',
   'cdsDeposit.components',
+  'LocalStorageModule',
 ]).config(cdsDepositsConfig);
 
 angular

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -9,7 +9,8 @@ function cdsDepositsCtrl(
   depositActions,
   depositSSEEvents,
   cdsAPI,
-  urlBuilder
+  urlBuilder,
+  localStorageService
 ) {
   var that = this;
   this.edit = false;
@@ -136,7 +137,7 @@ function cdsDepositsCtrl(
   };
 
   this.isVideoFile = function(key) {
-    var videoExtensions = (that.videoExtensions || 'mp4,mov').split(',');
+    var videoExtensions = (that.videoExtensions || 'mp4,mkv,mov').split(',');
     var fileKey = null;
     videoExtensions.forEach(function(ext) {
       if (key.toLowerCase().endsWith('.' + ext.toLowerCase())) {
@@ -230,10 +231,17 @@ function cdsDepositsCtrl(
                 that.childrenInit,
                 that.childrenSchema,
                 'video',
-                { _project_id: master_id }
+                {
+                  _project_id: master_id,
+                  title: { title: key }
+                }
               );
             },
             function(response) {
+              // Map from deposit IDs to video basenames (local storage)
+              videoId = response.data.metadata._deposit.id
+              localStorageService.set(videoId, {'basename': key})
+
               var _f = [];
               _f.push(file);
               _f = _f.concat(_files.videoFiles[key] || []);
@@ -390,6 +398,7 @@ cdsDepositsCtrl.$inject = [
   'depositSSEEvents',
   'cdsAPI',
   'urlBuilder',
+  'localStorageService',
 ];
 
 function cdsDeposits() {

--- a/cds/modules/deposit/static/json/cds_deposit/forms/video.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/video.json
@@ -258,7 +258,6 @@
         {
           "key": "copyright.holder",
           "title": "Holder",
-          "type": "string",
           "onChange": "$ctrl.checkCopyright(modelValue,form)"
         },
         {

--- a/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/video/form.html
@@ -4,6 +4,23 @@
     {{ alert.message }}
   </div>
 </div>
+<div class="alert alert-warning alert-dismissible" role="alert" ng-show="$ctrl.cdsDepositCtrl.metadataToFill">
+  <button ng-click="$ctrl.cdsDepositCtrl.dismissAlert(this)" type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  Extracted metadata can be used to automatically fill part of the form.
+  <button ng-click="metadataModal = true" class="btn-default">Fill</button>
+</div>
+<modal-dialog show="metadataModal" dialog-title="Are you sure you want to use the following metadata?" width="75%">
+  <ul>
+    <li ng-repeat="(key,value) in $ctrl.cdsDepositCtrl.getMetadataToDisplay()">
+      <strong>{{key}}</strong> {{value}}
+    </li>
+  </ul>
+  <p class="pull-right">
+    <button class="btn btn-success" ng-click="$ctrl.cdsDepositCtrl.fillMetadata(true) ; $parent.hideModal()">Yes</button>
+    <button class="btn btn-danger" ng-click="$ctrl.cdsDepositCtrl.fillMetadata(false) ; $parent.hideModal()">No</button>
+  </p>
+</modal-dialog>
+
 
 <div>
   <div class="row">

--- a/cds/modules/webhooks/tasks.py
+++ b/cds/modules/webhooks/tasks.py
@@ -297,7 +297,9 @@ class ExtractMetadataTask(AVCTask):
         self.update_state(
             state=SUCCESS,
             meta=dict(
-                payload=dict(tags=tags,),
+                payload=dict(
+                    tags=tags,
+                    extracted_metadata=extracted_dict,),
                 message='Attached video metadata'))
 
 


### PR DESCRIPTION
* Sets a video's title to its basename (i.e. filename without extension)
  on upload, in order for the user to be able to identify individual
  uploads. (closes #561)

* On completion of the `ExtractMetadataTask`, a video's default title
  can get overwritten by the one inside the extracted metadata, if it
  exists. (closes #425)

* Adds local storage for keeping track of video basenames and extracted
  metadata.

* Fixes issue with prefilled `copyright.year` being an integer, instead
  of a string.

* Adds `mov` to the default video extensions.

* Adds `extracted_metadata` inside the payload of the `on_success` SSE of
  the `ExtractMetadataTask`, in order to prefill desired information
  immediately without having to wait for an `update_deposit` SSE.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>