### PR TITLE
redirector: embed link fix

### DIFF
--- a/cds/modules/redirector/views.py
+++ b/cds/modules/redirector/views.py
@@ -38,7 +38,7 @@ blueprint = Blueprint(
 
 
 # /record/<pid_value>/embed/<filename>
-# /video/<report_number>/
+# /video/<report_number>
 @blueprint.route('/video/<report_number>')
 def video_embed_alias(report_number):
     """Redirect from the old video embed URL to the new one."""
@@ -52,6 +52,5 @@ def video_embed_alias(report_number):
         object_uuid=object_uuid
     ).one().pid_value
     return redirect(url_for(
-        'invenio_records_ui.recid_embed',
-        pid_value=recid,
-        filename=''), code=301)
+        'invenio_records_ui.recid_embed_default',
+        pid_value=recid), code=301)

--- a/tests/unit/test_previewer.py
+++ b/tests/unit/test_previewer.py
@@ -138,9 +138,8 @@ def test_legacy_embed(previewer_app, db, api_project, video):
     with previewer_app.test_client() as client:
         res = client.get('/video/{0}'.format(video_1.report_number))
         assert res.location.endswith(url_for(
-            'invenio_records_ui.recid_embed',
+            'invenio_records_ui.recid_embed_default',
             pid_value=video_1['recid'],
-            filename='',
         ))
 
 


### PR DESCRIPTION
* Uses `recid_embed_default` instead of `recid_embed`.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>