### PR TITLE
fixtures: fix report number generation

### DIFF
--- a/cds/modules/fixtures/cli.py
+++ b/cds/modules/fixtures/cli.py
@@ -312,10 +312,10 @@ def sequence_generator():
     """Register CDS templates for sequence generation."""
     with db.session.begin_nested():
         Template.create(name='project-v1_0_0',
-                        meta_template='{category}-{type}-{year}-{counter}',
+                        meta_template='{category}-{type}-{year}-{counter:03d}',
                         start=1)
         Template.create(name='video-v1_0_0',
-                        meta_template='{project-v1_0_0}-{counter}',
+                        meta_template='{project-v1_0_0}-{counter:03d}',
                         start=1)
     db.session.commit()
 

--- a/cds/modules/fixtures/data/categories.json
+++ b/cds/modules/fixtures/data/categories.json
@@ -1,27 +1,27 @@
 [
   {
     "name": "CERN",
-    "types": ["footage", "video"],
+    "types": ["FOOTAGE", "VIDEO"],
     "_record_type": ["PROJECT"]
   },
   {
     "name": "ATLAS",
-    "types": ["video"],
+    "types": ["VIDEO"],
     "_record_type":  ["PROJECT"]
   },
   {
     "name": "CMS",
-    "types": ["video"],
+    "types": ["VIDEO"],
     "_record_type":  ["PROJECT"]
   },
   {
     "name": "OPEN",
-    "types": ["video"],
+    "types": ["VIDEO"],
     "_record_type":  ["PROJECT"]
   },
   {
     "name": "SCADA",
-    "types": ["video"],
+    "types": ["VIDEO"],
     "_record_type":  ["PROJECT"]
   }
 ]

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -96,7 +96,7 @@ def test_fixture_categories(app, script_info, db, es, cds_jsonresolver):
     categories = RecordMetadata.query.all()
     assert len(categories) == 5
     for category in categories:
-        assert 'video' in category.json['types']
+        assert 'VIDEO' in category.json['types']
 
 
 def test_fixture_sequence_generator(app, script_info, db):


### PR DESCRIPTION
* Uses 3 digits for the counters in the sequence generator templates
  and upper case for the category types. (closes #666)