### PR TITLE
deposit: custom keywords and authors

### DIFF
--- a/cds/modules/deposit/static/json/cds_deposit/forms/project.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/project.json
@@ -103,9 +103,14 @@
         "inline": true,
         "items": [
           {
+            "type": "template",
+            "templateUrl": "/static/templates/cds_deposit/types/common/custom_authors_dialog.html"
+          },
+          {
             "type": "uiselect",
             "key": "contributors[]",
             "title": "Name",
+            "description": "",
             "placeholder": "Author name",
             "options": {
               "refreshDelay": 100,

--- a/cds/modules/deposit/static/json/cds_deposit/forms/video.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/video.json
@@ -155,10 +155,15 @@
       "inline": true,
       "items": [
         {
+          "type": "template",
+          "templateUrl": "/static/templates/cds_deposit/types/common/custom_authors_dialog.html"
+        },
+        {
           "type": "uiselect",
           "key": "contributors[]",
           "placeholder": "Author name",
           "title": "Name",
+          "description": "",
           "options": {
             "refreshDelay": 100,
             "mergeObjects": true,
@@ -245,7 +250,6 @@
         },
         {
           "key": "license[].material",
-          "placeholder": "Material",
           "placeholder": "Material"
         },
         {

--- a/cds/modules/deposit/static/templates/cds_deposit/types/common/custom_authors_dialog.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/common/custom_authors_dialog.html
@@ -1,0 +1,5 @@
+<a ng-click="form.infoShown = true"><i class="pull-right fa fa-info"></i></a>
+<modal-dialog show="form.infoShown" dialog-title="Custom authors" width="75%">
+    <p>Start by typing an author name and suggestions will become available to choose from.</p>
+    <p>If you wish to enter a custom author please use this format: "Lastname, Firstname: Affiliation"</p>
+</modal-dialog>

--- a/cds/modules/records/serializers/schemas/common.py
+++ b/cds/modules/records/serializers/schemas/common.py
@@ -55,8 +55,8 @@ class StrictKeysSchema(Schema):
 class KeywordsSchema(Schema):
     """Keywords schema."""
 
-    key_id = fields.Method(deserialize='get_keywords_refs',
-                           attribute='$ref')
+    name = fields.Str()
+    key_id = fields.Method(deserialize='get_keywords_refs', attribute='$ref')
 
     def get_keywords_refs(self, obj):
         """Get keywords references."""

--- a/tests/unit/test_video_rest.py
+++ b/tests/unit/test_video_rest.py
@@ -189,7 +189,10 @@ def test_video_publish_registering_the_datacite_not_local(
         assert project_dict['metadata']['keywords'][0] == keyword_2
         project_depid = project_dict['metadata']['_deposit']['id']
         project = project_resolver(project_depid)
-        assert project['keywords'] == [{'$ref': keyword_2.ref}]
+        assert project['keywords'] == [{
+            '$ref': keyword_2.ref,
+            'name': keyword_2['name'],
+        }]
 
         # [[ ADD A NEW VIDEO_1 ]]
         video_metadata = copy.deepcopy(video_deposit_metadata)
@@ -206,7 +209,10 @@ def test_video_publish_registering_the_datacite_not_local(
         assert video_1_dict['metadata']['keywords'][0] == keyword_1
         video_1_depid = video_1_dict['metadata']['_deposit']['id']
         [video_1] = video_resolver([video_1_depid])
-        assert video_1['keywords'] == [{'$ref': keyword_1.ref}]
+        assert video_1['keywords'] == [{
+            '$ref': keyword_1.ref,
+            'name': keyword_1['name'],
+        }]
         video_1['doi'] = '10.1123/doi'
         prepare_videos_for_publish([video_1])
 


### PR DESCRIPTION
* Allows adding custom keywords in deposit form field. (closes #683)

* Allows adding custom authors in deposit form field, in the form
  `<FirstName>, <LastName>: <Affiliation>`. (closes #682)

* Removes schema description from authors' field. (closes #730)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>