### PR TITLE
deposit: create extra tags on video publish

### DIFF
--- a/cds/modules/fixtures/cli.py
+++ b/cds/modules/fixtures/cli.py
@@ -49,7 +49,9 @@ from invenio_records_files.models import RecordsBuckets
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_opendefinition.tasks import harvest_licenses, \
     import_licenses_from_json
-from cds.modules.records.tasks import keywords_harvesting
+
+from ..records.tasks import keywords_harvesting
+from .video_utils import add_master_to_video
 
 
 def _load_json_source(filename):
@@ -436,16 +438,11 @@ def videos(video, frames, temp, video_count):
 
             # Master video
             with open(video, 'rb') as fp:
-                master_obj = ObjectVersion.create(
-                    bucket=video_bucket,
-                    key='video{0}.mp4'.format(video_index),
-                    stream=fp)
-            create_tags(
-                master_obj, display_aspect_ratio='16:9', bit_rate='959963',
-                codec_name='h264', duration=video_duration, nb_framesr='1557',
-                size='10498667', media_type='video', context_type='master',
-                avg_frame_rate='25/1', width='1280', height='720')
-            master_id = str(master_obj.version_id)
+                master_id = add_master_to_video(
+                    video_deposit=video_deposit,
+                    filename='video{0}.mp4'.format(video_index),
+                    stream=fp, video_duration=video_duration
+                )
 
             # Slave videos
             number_of_frames = len(frame_files)

--- a/cds/modules/fixtures/video_utils.py
+++ b/cds/modules/fixtures/video_utils.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016, 2017 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""CDS Fixture Modules."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_files_rest.models import ObjectVersion, ObjectVersionTag, Bucket
+
+
+def _create_tags(video_obj, **tags):
+    """Create multiple tags for a single object version."""
+    [ObjectVersionTag.create(video_obj, tag, tags[tag]) for tag in tags]
+
+
+def add_master_to_video(video_deposit, filename, stream, video_duration):
+    """Add a master file inside video."""
+    video_bucket = Bucket.get(video_deposit['_buckets']['deposit'])
+    # Master video
+    master_obj = ObjectVersion.create(bucket=video_bucket, key=filename,
+                                      stream=stream)
+    _create_tags(
+        master_obj, display_aspect_ratio='16:9', bit_rate='959963',
+        codec_name='h264', duration=video_duration, nb_framesr='1557',
+        size='10498667', media_type='video', context_type='master',
+        avg_frame_rate='25/1', width='1280', height='720')
+    return str(master_obj.version_id)

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -51,7 +51,8 @@ from invenio_webhooks.models import Event
 from six import BytesIO
 
 from helpers import failing_task, get_object_count, get_tag_count, \
-    simple_add, mock_current_user, success_task, get_indexed_records_from_mock
+    simple_add, mock_current_user, success_task, \
+    get_indexed_records_from_mock
 
 
 @mock.patch('flask_login.current_user', mock_current_user)


### PR DESCRIPTION
* Adds a function to create extra tags on video publish. (closes #727)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>