### PR TITLE
video: no escaped characters in description

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -478,6 +478,10 @@ function cdsDepositCtrl(
       $scope.$emit('cds.deposit.status.changed', that.id, that.stateQueue);
     };
 
+    this.refreshDescription = function() {
+      that.escapedDescription = $sce.trustAsHtml(that.record.description.value);
+    }
+
     // Initialize state the queue
     this.initializeStateQueue();
     // Initialize state reporter
@@ -490,6 +494,7 @@ function cdsDepositCtrl(
     that.fetchCurrentStatuses();
     that.fetchStatusInterval = $interval(that.fetchCurrentStatuses, 15000);
     $scope.$watch('$ctrl.taskState', that.refreshStateQueue, true);
+    $scope.$watch('$ctrl.record.description.value', that.refreshDescription, true);
 
     // Set the deposit State
     this.depositStatusCurrent = this.calculateStatus();

--- a/cds/modules/deposit/static/templates/cds_deposit/types/project/form.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/types/project/form.html
@@ -11,7 +11,7 @@
       <div class="row">
         <div class="col-sm-9">
           <h3 class="mb-5 mt-0">{{ $ctrl.cdsDepositCtrl.record.title.title || 'No project title'}}</h3>
-          <p>{{ $ctrl.cdsDepositCtrl.record.description.value || 'No description'}}</p>
+          <p ng-bind-html="$ctrl.cdsDepositCtrl.escapedDescription || 'No description'"></p>
         </div>
         <div class="col-sm-3">
           <div class="text-right">

--- a/cds/modules/records/static/templates/cds_records/video/detail.html
+++ b/cds/modules/records/static/templates/cds_records/video/detail.html
@@ -63,7 +63,7 @@
           <hr />
           <div class="cds-detail-description cds-detail-video-description t-b">
             <p class="mb-20"><strong>Uploaded on {{ ::record.metadata.date }}</strong></p>
-            <p class="f7 mb-20">{{ ::record.metadata.description.value }}</p>
+            <p class="f7 mb-20" ng-bind-html="escapedDescription"></p>
             <p class="text-muted mt-10 mb-0">
               <a ng-href="/search?q=_project_id:{{:: record.metadata._project_id}}">Other videos in this project</a>
             </p>


### PR DESCRIPTION
* Properly display the escaped characters in the record description and
  the description when editing the deposit.

Depends on https://github.com/CERNDocumentServer/cds-js/pull/10

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>