### PR TITLE
video: additional information in detail view

### DIFF
--- a/cds/modules/records/static/templates/cds_records/keywords.html
+++ b/cds/modules/records/static/templates/cds_records/keywords.html
@@ -1,9 +1,9 @@
-<div ng-if="record.metadata.keywords.length === 0">
-  <hr />
-  <div class="cds-tags">
+<div class="row" ng-if="record.metadata.keywords.length > 0">
+  <p class="col-sm-2"><strong>Keywords</strong></p>
+  <div class="cds-tags col-sm-offset-1 col-sm-6">
     <ul>
       <li ng-repeat="keyword in record.metadata.keywords">
-        <a ng-href='/search?q="{{ keyword.name }}"'>{{ keyword }}</a>
+        <a ng-href='/search?q="{{ keyword.name }}"'>{{ keyword.name }}</a>
       </li>
     </ul>
   </div>

--- a/cds/modules/records/static/templates/cds_records/video/detail.html
+++ b/cds/modules/records/static/templates/cds_records/video/detail.html
@@ -39,7 +39,9 @@
           <div class="cds-detail-title cds-detail-video-title">
             <hgroup>
               <h1 class="mb-0 f4 fw-n t-b">{{ ::record.metadata.title.title }}</h1>
-              <h2 class="cds-detail-secondary-title text-muted mt-0 f4 fw-n"><em>{{ ::record.metadata.title.title }}</em></h2>
+              <h2 ng-repeat="translation in record.metadata.translations" class="cds-detail-secondary-title text-muted mt-0 f4 fw-n" ng-if="translation.language == 'fr'">
+                <em>{{ ::translation.title.title }}</em>
+              </h2>
             </hgroup>
           </div>
           <!-- /Title -->
@@ -63,13 +65,27 @@
           <hr />
           <div class="cds-detail-description cds-detail-video-description t-b">
             <p class="mb-20"><strong>Uploaded on {{ ::record.metadata.date }}</strong></p>
-            <p class="f7 mb-20">{{ ::record.metadata.description.value }}</p>
-            <p class="text-muted mt-10 mb-0">
+            <p class="f8 mb-20">{{ ::record.metadata.description.value }}</p>
+            <p class="text-muted mt-10 mb-0 pull-right">
               <a ng-href="/search?q=_project_id:{{:: record.metadata._project_id}}">Other videos in this project</a>
             </p>
           </div>
           <!-- /Description -->
           <!-- More -->
+          <div ng-if="record.metadata.language" class="row cds-detail-language cds-detail-more cds-detail-video-more">
+              <strong class="col-sm-2">Language</strong>
+              <span class="col-sm-offset-1 col-sm-4">{{ record.metadata.language }}</span>
+          </div>
+          <div ng-if="record.metadata.contributors.length" class="row cds-detail-contributors cds-detail-more cds-detail-video-more">
+            <strong class="col-sm-2">Contributors</strong>
+            <div class="col-sm-offset-1 col-sm-4">
+              <ul class="list-inline">
+                <li ng-repeat="contrib in record.metadata.contributors">
+                  {{ contrib.name }} - {{ contrib.role }}
+                </li>
+              </ul>
+            </div>
+          </div>
           <div class="cds-detail-more cds-detail-video-more">
             <ng-include src="'/static/templates/cds_records/keywords.html'"></ng-include>
           </div>

--- a/cds/modules/records/static/templates/cds_records/video/downloads.html
+++ b/cds/modules/records/static/templates/cds_records/video/downloads.html
@@ -32,7 +32,7 @@
     <ul ng-repeat="file in record.metadata._files">
       <li>
         <a ng-href="{{ file.links.self }}">
-          {{ file.tags.preset_quality }}
+          {{ file.key }}
         </a>
       </li>
     </ul>

--- a/cds/modules/theme/static/scss/cds.scss
+++ b/cds/modules/theme/static/scss/cds.scss
@@ -144,7 +144,7 @@ i.sort-handle {
   line-height: 28px;
   padding: 0 1em;
   background-color: #fff;
-  border: 1px solid $bg-gray;
+  border: 1px solid $divider-color;
   border-radius: 3px;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -549,9 +549,9 @@ i.sort-handle {
 }
 
 .cds-video-duration {
-  position: absolute;
-  bottom: 5px;
-  left: 5px;
+  position: relative;
+  bottom: 27px;
+  left: 2px;
   padding: 3px;
   font-size: 12px;
   background-color: rgba(0, 0, 0, .75);


### PR DESCRIPTION
* Add authors, keywords, language to detail view.

* Reduce description font size.

* Show file key for additional files.

* Show actual translated titles.

* Fix incorrect timestamp placement on video search results on Firefox.

![2017-04-27-182612_4920x1920_scrot](https://cloud.githubusercontent.com/assets/5767669/25493741/83881e54-2b77-11e7-8488-b6d3eea8e899.png)


Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>