### PR TITLE
deposit: project publish fix

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/providers/depositActions.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/providers/depositActions.js
@@ -33,7 +33,8 @@ function depositActions() {
           },
           PUBLISH: {
             method: 'POST',
-            link: 'publish'
+            link: 'publish',
+            preprocess: sanitizeData
           },
           DELETE: {
             method: 'DELETE',


### PR DESCRIPTION
* Sanitizes deposit metadata on publish, in order to remove empty values
  inside `_access.update`. (closes #745)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>