### PR TITLE
deposit: UI fixes and improvements

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -875,6 +875,7 @@ DEPOSIT_FORM_TEMPLATES = {
     'textarea': 'textarea.html',
     'checkbox': 'checkbox.html',
     'uiselectmultiple': 'uiselectmultiple.html',
+    'strapselect': 'strapselect.html',
 }
 
 # App key for uploading files from dropbox

--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposits.js
@@ -302,11 +302,11 @@ function cdsDepositsCtrl(
   };
 
   this.makeAction = function(url, depositType, action, payload) {
-    var { method, headers, preprocess } = depositActions[depositType][action];
-    if (preprocess) {
-      payload = preprocess(payload);
+    var actionInfo = depositActions[depositType][action];
+    if (actionInfo.preprocess) {
+      payload = actionInfo.preprocess(payload);
     }
-    return cdsAPI.action(url, method, payload, headers);
+    return cdsAPI.action(url, actionInfo.method, payload, actionInfo.headers);
   };
 
   this.chainedActions = function(promises) {

--- a/cds/modules/deposit/static/json/cds_deposit/forms/project.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/project.json
@@ -69,6 +69,7 @@
         "title": "Type",
         "type": "strapselect",
         "htmlClass": "cds-deposit-strap-select",
+        "readonly": "!model.category",
         "options": {
           "filterTriggers": ["model.category"],
           "filter" : "item.category == model.category",
@@ -311,7 +312,8 @@
       "title": "Update access for the project",
       "description": "",
       "add": "Add another person/e-group",
-      "inline": true
+      "inline": true,
+      "startEmpty": true
     }
   ]
 }

--- a/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/strapselect.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/strapselect.html
@@ -1,0 +1,25 @@
+<fieldset ng-controller="dynamicSelectController" class="form-group {{form.htmlClass}}"
+     ng-disabled="$eval(form.readonly)"
+     ng-class="{'has-error': hasError(), 'has-success': hasSuccess()}">
+    <label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label>
+    <div class="form-group {{form.fieldHtmlClass}}" ng-init="populateTitleMap(form)">
+        <button ng-if="(form.options.multiple == 'true') || (form.options.multiple == true)"
+                type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
+                data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
+                data-html="1" data-multiple="1" data-max-length="{{form.options.inlineMaxLength}}"
+				data-placement="{{form.options.placement || 'bottom-left'}}"
+                data-max-length-html="{{form.options.inlineMaxLengthHtml}}" ng-disabled="form.disabled"
+                bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
+                bs-select>
+        </button>
+        <button ng-if="!((form.options.multiple == 'true') || (form.options.multiple == true))"
+                type="button" class="btn btn-default" sf-changed="form" schema-validate="form" ng-model="$$value$$"
+                data-placeholder="{{form.placeholder || form.schema.placeholder || ('placeholders.select')}}"
+                data-html="1" ng-disabled="form.disabled"
+				data-placement="{{form.options.placement || 'bottom-left'}}"
+                bs-options="item.value as item.name for item in form.titleMap | selectFilter:this:$$value$$:&quot;$$value$$&quot;"
+                bs-select>
+        </button>
+        <span class="help-block">{{ (hasError() && errorMessage(schemaError())) || form.description}} </span>
+    </div>
+</fieldset>


### PR DESCRIPTION
* Fixes issue with access rights' field being empty by default.

* Makes the dependency `Type` has on `Category` more apparent to the
  user. (closes #759)

* Fixes issues with confusing initial suggestions on `multiselect`
  fields. (closes #741)

* Improves experience of `Author` autocompletion (e.g. stripping commas).

* `Keyword` autocompletion is now case-insensitive.

Signed-off-by: Orestis Melkonian melkon.or@gmail.com