### PR TITLE
redirector: drupal export legacy endpoint

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -161,22 +161,27 @@ REST_ENABLE_CORS = True
 CDS_RECORDS_EXPORTFORMATS = {
     'json': dict(
         title='JSON',
+        mimetype='application/json',
         serializer='invenio_records_rest.serializers:json_v1'
     ),
     'smil': dict(
         title='SMIL',
+        mimetype='application/smil',
         serializer='cds.modules.records.serializers:smil_v1'
     ),
     'vtt': dict(
         title='VTT',
+        mimetype='text/vtt',
         serializer='cds.modules.records.serializers:vtt_v1'
     ),
     'drupal': dict(
         title='Drupal',
+        mimetype='x-application/drupal',
         serializer='cds.modules.records.serializers:drupal_v1'
     ),
     'dcite': dict(
         title='Datacite XML v3.1',
+        mimetype='application/x-datacite+xml',
         serializer='cds.modules.records.serializers:datacite_v31'
     )
 }
@@ -230,18 +235,10 @@ RECORDS_UI_ENDPOINTS = dict(
     recid_export=dict(
         pid_type='recid',
         route='/record/<pid_value>/export/<any({0}):format>'.format(
-            ", ".join(
-                [k for k in CDS_RECORDS_EXPORTFORMATS.keys() if k != 'vtt']
-            )
+            ", ".join(list(CDS_RECORDS_EXPORTFORMATS.keys()))
         ),
         template='cds_records/record_export.html',
         view_imp='cds.modules.records.views.records_ui_export',
-        record_class='invenio_records_files.api:Record',
-    ),
-    recid_export_vtt=dict(
-        pid_type='recid',
-        route='/record/<pid_value>/export/<any(vtt):format>',
-        view_imp='cds.modules.records.views.records_ui_export_vtt',
         record_class='invenio_records_files.api:Record',
     ),
 )

--- a/cds/modules/previewer/api.py
+++ b/cds/modules/previewer/api.py
@@ -72,8 +72,7 @@ class CDSPreviewRecordFile(PreviewFile):
         """Get video's thumbnails' link."""
         return url_for(
             'invenio_records_ui.{0}_export'.format(self.pid.pid_type),
-            pid_value=self.pid.pid_value,
-            format='vtt')
+            pid_value=self.pid.pid_value, format='vtt', raw=True)
 
     @property
     def subtitles(self):

--- a/cds/modules/records/views.py
+++ b/cds/modules/records/views.py
@@ -45,21 +45,18 @@ def records_ui_export(pid, record, template=None, **kwargs):
     else:
         serializer = import_string(formats[fmt]['serializer'])
         data = serializer.serialize(pid, record)
-        if isinstance(data, six.binary_type):
-            data = data.decode('utf8')
+        if 'raw' in request.args:
+            response = make_response(data)
+            response.headers['Content-Type'] = formats[fmt]['mimetype']
+            return response
+        else:
+            if isinstance(data, six.binary_type):
+                data = data.decode('utf8')
 
-        return render_template(
-            template,
-            pid=pid,
-            record=record,
-            data=data,
-            format_title=formats[fmt]['title']
-        )
-
-
-def records_ui_export_vtt(pid, record, **kwargs):
-    """Export a record as a VTT file."""
-    data = VTTSerializer().serialize(pid, record)
-    response = make_response(data)
-    response.headers['Content-Type'] = 'text/vtt'
-    return response
+            return render_template(
+                template,
+                pid=pid,
+                record=record,
+                data=data,
+                format_title=formats[fmt]['title']
+            )

--- a/setup.py
+++ b/setup.py
@@ -123,10 +123,8 @@ install_requires = [
     'invenio-rest[cors]>=1.0.0a9',
     'invenio-search-ui>=1.0.0a5',
     'invenio-search>=1.0.0a7',
-    # FIXME wait until invenio-sequencegenerator is released
-    #  'invenio-sequencegenerator>=1.0.0a1',
-    # FIXME wait until invenio-sse is released
-    #  'invenio-sse>=1.0.0a1',
+     'invenio-sequencegenerator>=1.0.0a1',
+     'invenio-sse>=1.0.0a1',
     'invenio-theme>=1.0.0a14',
     'invenio-userprofiles>=1.0.0a7',
     'invenio-webhooks>=1.0.0a4',


### PR DESCRIPTION
* Adds a redirection endpoint for the legacy drupal export
  (i.e. `/api/mediaexport?id=<rn>`). (closes #417)

* Enables serving serialized records immediately from the UI via
  adding the `raw` query string in `record/<recid>/export/<format>?raw`.

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>