### PR TITLE
deposit: proper form state after inheriting metadata

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsDeposit.js
@@ -106,6 +106,7 @@ function cdsDepositCtrl(
     };
 
     this.inheritMetadata = function(specific) {
+      // Inherit metadata from project
       var record = that.record;
       var master = that.cdsDepositsCtrl.master.metadata;
       var paths = (specific !== undefined ) ? specific : inheritedProperties;
@@ -120,6 +121,8 @@ function cdsDepositCtrl(
           accessElement(record, propPath, inheritedArray);
         }
       });
+      // Set form dirty
+      that.setDirty();
     };
 
     this.getTaskFeedback = function(eventId, taskName, taskStatus) {
@@ -657,6 +660,14 @@ function cdsDepositCtrl(
 
   this.isInvalid = function() {
     return that.depositFormModels.some(_.property('$invalid'))
+  }
+
+  this.setDirty = function() {
+    _.invoke(that.depositFormModels, '$setDirty');
+  }
+
+  this.setPristine = function() {
+    _.invoke(that.depositFormModels, '$setPristine');
   }
 
   // Local storage


### PR DESCRIPTION
* Makes a video's form `dirty` after inheriting metadata from project.
  (closes #807)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>