### PR TITLE
deposit: permanent store celery tasks status

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -93,6 +93,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'invenio_accounts.tasks.clean_session_table',
         'schedule': timedelta(days=1),
     },
+    'tasks_status': {
+        'task': 'cds.modules.deposit.tasks.preserve_celery_states_on_db',
+        'schedule': timedelta(days=1),
+    },
 }
 
 ###############################################################################

--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -679,7 +679,8 @@ class Project(CDSDeposit):
         """Return up-to-date tasks status."""
         list_events = [get_deposit_events(depid) for depid in self.video_ids]
         events = list(itertools.chain.from_iterable(list_events))
-        return get_tasks_status_by_task(events)
+        return get_tasks_status_by_task(
+            events, statuses=deepcopy(self['_deposit'].get('state', {})))
 
     @classmethod
     def build_video_ref(cls, video):
@@ -845,7 +846,8 @@ class Video(CDSDeposit):
     def _current_tasks_status(self):
         """Return up-to-date tasks status."""
         return get_tasks_status_by_task(
-            get_deposit_events(self['_deposit']['id']))
+            get_deposit_events(self['_deposit']['id']),
+            statuses=deepcopy(self['_deposit'].get('state', {})))
 
     def generate_duration(self):
         """Generate human-readable duration field."""

--- a/cds/modules/deposit/indexer.py
+++ b/cds/modules/deposit/indexer.py
@@ -26,15 +26,9 @@
 
 from __future__ import absolute_import, print_function
 
-from flask import current_app
-from werkzeug.local import LocalProxy
+from invenio_jsonschemas import current_jsonschemas
 
 from .api import Video, Project
-
-
-current_jsonschemas = LocalProxy(
-    lambda: current_app.extensions['invenio-jsonschemas']
-)
 
 
 def cdsdeposit_indexer_receiver(

--- a/cds/modules/deposit/search.py
+++ b/cds/modules/deposit/search.py
@@ -93,3 +93,22 @@ class DepositVideosSearch(RecordsSearch):
         doc_types = None
         fields = ('*', )
         default_filter = DefaultFilter(cern_filter)
+
+
+def all_drafts_filter():
+    """Filter published videos/projects."""
+    return Q('bool', filter=[
+        Q('match', **{'_deposit.status': 'draft'})
+    ])
+
+
+class AllDraftDepositsSearch(RecordsSearch):
+    """Default search class."""
+
+    class Meta:
+        """Configuration to get all deposits project/videos."""
+
+        index = 'deposits-records-videos'
+        doc_types = None
+        fields = ('*', )
+        default_filter = DefaultFilter(all_drafts_filter)

--- a/cds/modules/deposit/tasks.py
+++ b/cds/modules/deposit/tasks.py
@@ -32,7 +32,10 @@ from celery import shared_task
 from invenio_records_files.api import Record
 from invenio_pidstore.models import PIDStatus
 from invenio_pidstore.providers.datacite import DataCiteProvider
+from invenio_jsonschemas import current_jsonschemas
 
+from .api import Video, Project
+from .search import AllDraftDepositsSearch
 from ...modules.records.serializers import datacite_v31
 from ...modules.records.minters import is_local_doi
 
@@ -66,3 +69,46 @@ def datacite_register(
     except Exception as exc:
         db.session.rollback()
         raise self.retry(max_retries=max_retries, countdown=countdown, exc=exc)
+
+
+def _is_state_changed(record, deposit):
+    """Return True if the celery tasks state changed."""
+    state_r = record['_deposit'].get('state', {})
+    state_d = deposit['_deposit'].get('state', {})
+    return state_r != state_d
+
+
+def _get_deposits_split_by_type(query):
+    """Get video/projects and both as records."""
+    video_schema = current_jsonschemas.path_to_url(Video._schema)
+    project_schema = current_jsonschemas.path_to_url(Project._schema)
+    # get list of videos, project and both as records
+    video_ids = []
+    project_ids = []
+    record_ids = []
+    for data in query.scan():
+        if data['$schema'] == project_schema:
+            project_ids.append(data.meta.id)
+        if data['$schema'] == video_schema:
+            video_ids.append(data.meta.id)
+        record_ids.append(data.meta.id)
+    records = {r.id: r for r in Record.get_records(record_ids)}
+    projects = Project.get_records(project_ids)
+    videos = Video.get_records(video_ids)
+    return (videos, projects, records)
+
+
+@shared_task(ignore_result=True, rate_limit='100/m',
+             default_retry_delay=10 * 60)
+def preserve_celery_states_on_db():
+    """Preserve in db the celery tasks state."""
+    (videos, projects, records) = _get_deposits_split_by_type(
+        query=AllDraftDepositsSearch())
+    # commit only the ones who should be update
+    for video in videos:
+        if _is_state_changed(records[video.id], video):
+            video.commit()
+    for project in projects:
+        if _is_state_changed(records[project.id], project):
+            project.commit()
+    db.session.commit()

--- a/tests/unit/test_webhook_receivers.py
+++ b/tests/unit/test_webhook_receivers.py
@@ -886,7 +886,10 @@ def test_compute_status():
         states.RETRY, states.PENDING, states.SUCCESS, states.SUCCESS])
     assert states.PENDING == _compute_status([
         states.PENDING, states.PENDING, states.SUCCESS, states.SUCCESS])
+    assert states.SUCCESS == _compute_status([
+        states.SUCCESS, states.REVOKED, states.SUCCESS, states.SUCCESS])
     assert states.SUCCESS == _compute_status([states.SUCCESS, states.SUCCESS])
+    assert states.REVOKED == _compute_status([states.REVOKED, states.REVOKED])
 
 
 def test_collect_info():


### PR DESCRIPTION
* Saves permanently celery tasks status when required.
  (closes #790) (closes #786)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>