### PR TITLE
deposit: array.html now accepts minLength parameter

### DIFF
--- a/cds/modules/deposit/static/json/cds_deposit/forms/project.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/project.json
@@ -313,7 +313,10 @@
       "description": "",
       "add": "Add another person/e-group",
       "inline": true,
-      "startEmpty": true
+      "startEmpty": true,
+      "options": {
+        "minLength": 0
+      }
     }
   ]
 }

--- a/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/array.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/array.html
@@ -20,13 +20,13 @@
           class="close-container pull-right"
           style="padding-bottom: 20px"
           ng-class="{'clear-form': !form.inline}">
-          <i ng-hide="modelArray.length < 2" class="sort-handle fa fa-sort fa-fw" ng-if="form.sortOptions.disabled === false"></i>
+          <i ng-hide="modelArray.length <= (form.options.minLength == null ? 1 : form.options.minLength)" class="sort-handle fa fa-sort fa-fw" ng-if="form.sortOptions.disabled === false"></i>
           <button
             class="close"
             type="button"
-            ng-hide="evalExpr(form.readonly) || form.remove === null || modelArray.length < 2"
+            ng-hide="evalExpr(form.readonly) || form.remove === null || modelArray.length <= (form.options.minLength == null ? 1 : form.options.minLength)"
             ng-click="deleteFromArray($index)"
-            ng-disabled="modelArray.length < 2">
+            ng-disabled="modelArray.length <= (form.options.minLength === null ? 1 : form.options.minLength)">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>


### PR DESCRIPTION
* By adding 'minLength' parameter to the 'options' of a json form, one
  can specify when the 'Remove' button should be hidden for the arrays
  of elements (for example in contributors, translations or access)
  (closes #714).