### PR TITLE
deposit: drupal export fix

### DIFF
--- a/cds/modules/records/serializers/drupal.py
+++ b/cds/modules/records/serializers/drupal.py
@@ -116,7 +116,7 @@ class VideoDrupal(object):
     def keywords(self):
         """Get keywords."""
         keywords = self._record.get('keywords', [])
-        return ", ".join([keyword['value'] for keyword in keywords])
+        return ", ".join([keyword['name'] for keyword in keywords])
 
 
 class DrupalSerializer(JSONSerializer):


### PR DESCRIPTION
* Fixes issue with the Drupal serializer searching for a key in keyword
  objects that is not preserved on `marshmallow ` (de)serialization.
  (closes #838)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>