### PR TITLE
deposit: delete video fix

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsActions.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsActions.js
@@ -37,7 +37,7 @@ function cdsActionsCtrl($scope) {
       that.actionHandler('DELETE').then(function() {
         var children = that.cdsDepositCtrl.cdsDepositsCtrl.master.metadata.videos;
         for (var i in children) {
-          if (children[i].metadata._deposit.id == that.cdsDepositCtrl.id) {
+          if (children[i]._deposit.id == that.cdsDepositCtrl.id) {
             children.splice(i, 1);
           }
         }


### PR DESCRIPTION
## Depends on #841
* Fixes issue, where the UI deleted a video without updating the parent
  project's references. (closes #795)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>