### PR TITLE
deposit: proper form state after array reordering

### DIFF
--- a/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
+++ b/cds/modules/deposit/static/js/cds_deposit/avc/components/cdsForm.js
@@ -61,6 +61,11 @@ function cdsFormCtrl($scope, $http, $q, schemaFormDecorators) {
     }
   });
 
+  // Set form dirty when reordering UI-sortable arrays.
+  this.onSortableReorder = function(event, ui) {
+    that.cdsDepositCtrl.setDirty();
+  }
+
   this.removeValidationMessage = function(fieldValue, form) {
     // Reset validation only if the filed has been changed
     if (form.validationMessage) {

--- a/cds/modules/deposit/static/json/cds_deposit/forms/video.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/video.json
@@ -151,7 +151,8 @@
         "disabled": false,
         "handle": "i.sort-handle",
         "cursor": "move",
-        "axis": "y"
+        "axis": "y",
+        "update": "$ctrl.onSortableReorder"
       },
       "add": "Add another contributor",
       "inline": true,

--- a/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/array.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/array.html
@@ -11,7 +11,7 @@
     <i ng-if="form.fa_cls" class="fa fa-fw {{ form.fa_cls }}"></i>&nbsp;{{ form.title }}
   </label>
 
-    <ul class="list-unstyled" ng-model="modelArray" ui-sortable="form.sortOptions">
+    <ul class="list-unstyled" ng-model="modelArray" ui-sortable="evalExpr(form.sortOptions)">
       <li
         class="{{ form.fieldHtmlClass }} list-group-item"
         ng-class="{'deposit-inline': form.inline}"


### PR DESCRIPTION
* Fixes issue, where a form was still `pristine` (i.e. not `dirty`),
  after reordering an array's elements. (closes #705)

Signed-off-by: Orestis Melkonian <melkon.or@gmail.com>