### PR TITLE
webhooks: prevent extract metadata clean failure

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -110,6 +110,8 @@ def app():
         JSONSCHEMAS_HOST='cdslabs.cern.ch',
         DEPOSIT_UI_ENDPOINT='{scheme}://{host}/deposit/{pid_value}',
         PIDSTORE_DATACITE_DOI_PREFIX='10.0000',
+        # FIXME
+        ACCOUNTS_JWT_ENABLE=False,
     )
     app.register_blueprint(files_rest_blueprint)
 
@@ -150,8 +152,9 @@ def celery_not_fail_on_eager_app(app):
                 view_imp='cds.modules.previewer.views.preview_depid',
                 record_class='cds.modules.deposit.api:Video',
             ),
-        )
-
+        ),
+        # FIXME
+        ACCOUNTS_JWT_ENABLE=False,
     )
     app.register_blueprint(files_rest_blueprint)
 

--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -195,6 +195,12 @@ def test_metadata_extraction_video(app, db, cds_depid, bucket, video):
     tags = ObjectVersion.query.first().get_tags()
     assert len(tags) == 0
 
+    # Simulate failed task, no extracted_metadata
+    ExtractMetadataTask().clean(deposit_id=dep_id,
+                                version_id=obj_id)
+    record = Record.get_record(recid)
+    assert 'extracted_metadata' not in record['_deposit']
+
 
 def test_video_extract_frames(app, db, bucket, video):
     """Test extract frames from video."""


### PR DESCRIPTION
* When the tasks fails there is no `extracted_metadata` key to delete and therefore the clean method raises, this exception should only happen in this situation.