### PR TITLE
video: more options for the videos

### DIFF
--- a/cds/modules/records/serializers/smil.py
+++ b/cds/modules/records/serializers/smil.py
@@ -69,6 +69,10 @@ class Smil(object):
         master_file = CDSFilesIterator.get_master_video_file(record)
         for video in CDSFilesIterator.get_video_subformats(master_file):
             tags = video['tags']
+            if tags.get('no_smil'):
+                # If the 'no_smil' config variable is set,
+                # don't add this video to the SMIL file
+                continue
             yield dict(
                 src=get_relative_path(video['version_id']),
                 width=tags['width'],

--- a/cds/modules/webhooks/tasks.py
+++ b/cds/modules/webhooks/tasks.py
@@ -524,8 +524,11 @@ class TranscodeVideoTask(AVCTask):
             ObjectVersionTag.create(obj, 'media_type', 'video')
             ObjectVersionTag.create(obj, 'context_type', 'subformat')
             preset_info = get_preset_info(aspect_ratio, preset_quality)
-            [ObjectVersionTag.create(obj, key, preset_info[key])
-             for key in ['video_bitrate', 'width', 'height']]
+            for key in ['video_bitrate', 'width', 'height']:
+                ObjectVersionTag.create(obj, key, preset_info[key])
+            # Add additional config parameters
+            if preset_info.get('no_smil'):
+                ObjectVersionTag.create(obj, 'no_smil', 'true')
 
             # Information necessary for monitoring
             job_info = dict(

--- a/tests/unit/test_previewer.py
+++ b/tests/unit/test_previewer.py
@@ -168,6 +168,15 @@ def test_smil_generation(previewer_app, db, api_project, video):
                                      stream=open(video, 'rb'))
         ObjectVersionTag.create(slave, 'master', str(master_obj.version_id))
         create_video_tags(slave, context_type='subformat')
+    # Create one slave that shouldn't be added to the SMIL file
+    no_smil_slave = ObjectVersion.create(bucket=bucket_id,
+                                         key='test_no_smil.mp4',
+                                         stream=open(video, 'rb'))
+    ObjectVersionTag.create(no_smil_slave,
+                            'master',
+                            str(master_obj.version_id))
+    create_video_tags(no_smil_slave, context_type='subformat')
+    ObjectVersionTag.create(no_smil_slave, 'no_smil', 'true')
 
     prepare_videos_for_publish([video_1])
     video_1.publish()
@@ -189,6 +198,7 @@ def test_smil_generation(previewer_app, db, api_project, video):
             slave_key = '{0}_{1}.mp4'.format(basename, suffix)
             slave_obj = ObjectVersion.get(new_bucket, slave_key)
             assert get_relative_path(slave_obj) in contents
+        assert 'test_no_smil.mp4' not in contents
 
 
 def test_vtt_export(previewer_app, db, project_published,

--- a/tests/unit/test_webhook_tasks.py
+++ b/tests/unit/test_webhook_tasks.py
@@ -371,3 +371,26 @@ def test_transcode_ignore_exception_if_invalid(db, bucket):
         # Transcode
         task = task_s1.delay()
         isinstance(task.result, Ignore)
+
+
+def test_smil_generation(app, db, bucket, mock_sorenson):
+    """Test that smil files are generated correctly."""
+    # Setup and run the transcoding task
+    filename = 'test.mp4'
+    preset_quality = '1080ph265'
+    obj = ObjectVersion.create(bucket, key=filename,
+                               stream=BytesIO(b'\x00' * 1024))
+    ObjectVersionTag.create(obj, 'display_aspect_ratio', '16:9')
+    obj_id = str(obj.version_id)
+    db.session.commit()
+
+    task_s = TranscodeVideoTask().s(version_id=obj_id,
+                                    preset_quality=preset_quality,
+                                    sleep_time=0)
+    task_s.delay()
+
+    # Get the tags from the newly created slave
+    tags = ObjectVersionTag.query.filter_by(
+        value=obj_id).first().object_version.get_tags()
+    # Make sure the no_smil option is set
+    assert tags['no_smil'] == 'true'


### PR DESCRIPTION
* Adds 'smil' parameter to the ObjectVersionTag that allows you to
  specify that a given file should not be added to the SMIL file.

* Adds 'preview' parameter, that when set to 'False' means that this
  video should not be available for displaying in the browser (so
  only for download).