### PR TITLE
deposit: set minimum input lenght for autocomplete

### DIFF
--- a/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/uiselect.html
+++ b/cds/modules/deposit/static/templates/cds_deposit/angular-schema-form/uiselect.html
@@ -21,6 +21,7 @@
                 {{select_model.selected.name}}
             </ui-select-match>
       <ui-select-choices
+        minimum-input-length="{{ form.minLength || 3 }}"
         refresh="populateTitleMap(form, $select.search)"
         refresh-delay="form.options.refreshDelay"
         group-by="form.options.groupBy"


### PR DESCRIPTION
* Sets minimum input lenght for autocomplete author field.
  (closes #849)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>