### PR TITLE
serializers: change minimum title length

### DIFF
--- a/cds/modules/records/serializers/schemas/common.py
+++ b/cds/modules/records/serializers/schemas/common.py
@@ -99,7 +99,7 @@ class TitleSchema(StrictKeysSchema):
 
     source = fields.Str()
     subtitle = fields.Str()
-    title = fields.Str(required=True, allow_none=False, validate=Length(min=3))
+    title = fields.Str(required=True, allow_none=False, validate=Length(min=4))
 
 
 class CreatorSchema(StrictKeysSchema):


### PR DESCRIPTION
* Changes the minumum number of characters in the ``title`` from 3 to 4.
  (closes #848)

Signed-off-by: Harris Tzovanakis <me@drjova.com>