### PR TITLE
record: only downloadable subformats by default

### DIFF
--- a/cds/modules/records/static/templates/cds_records/video/downloads.html
+++ b/cds/modules/records/static/templates/cds_records/video/downloads.html
@@ -12,13 +12,26 @@
     <p class="text-muted">Not available :(</p>
   </div>
   <div ng-show="(record | findMaster).subformat.length > 0" class="cds-detail-download-box cds-detail-video-download-box">
-    <ul ng-repeat="file in (record | findMaster).subformat">
+    <ul ng-repeat="file in (record | findMaster).subformat" ng-if="file.tags.download">
       <li>
         <a ng-href="{{ file.links.self }}">
           {{ file.tags.preset_quality }} ({{ file.size | bytesToHumanReadable }})
         </a>
       </li>
     </ul>
+    <a ng-click="showAllDownloads = !showAllDownloads">
+      <p ng-show="showAllDownloads">Show less <i class="fa fa-angle-up"></i></p>
+      <p ng-show="!showAllDownloads">Show all <i class="fa fa-angle-down"></i></p>
+    </a>
+    <div ng-show="showAllDownloads">
+      <ul ng-repeat="file in (record | findMaster).subformat" ng-if="!file.tags.download">
+        <li>
+          <a ng-href="{{ file.links.self }}">
+            {{ file.tags.preset_quality }} ({{ file.size | bytesToHumanReadable }})
+          </a>
+        </li>
+      </ul>
+    </div>
   </div>
 </div>
 <!-- /Subformat -->


### PR DESCRIPTION
* Show only subformats with the download tag and only show the rest when
  the list is expanded.

Signed-off-by: Nikos Filippakis <nikolaos.filippakis@cern.ch>