### PR TITLE
webhooks: receiver permissions addition, fix access rights on video, set video owner always project owner 

### DIFF
--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -662,13 +662,13 @@ class Project(CDSDeposit):
         if video.get('_access', {}) != project_access or \
                 video['_deposit'].get('created_by') != project_created_by:
             changed = True
-        # sync access rights
-        video['_access'] = deepcopy(project_access)
-        # sync owner
-        try:
-            video['_deposit']['created_by'] = project_created_by
-        except KeyError:
-            pass
+            # sync access rights
+            video['_access'] = deepcopy(project_access)
+            # sync owner
+            try:
+                video['_deposit']['created_by'] = project_created_by
+            except KeyError:
+                pass
         return changed
 
 

--- a/cds/modules/fixtures/cli.py
+++ b/cds/modules/fixtures/cli.py
@@ -401,6 +401,7 @@ def videos(video, frames, temp, video_count):
 
         project = Project.create(
             dict(
+                contributors=[dict(name='contrib', role='Provider')],
                 date='2017-01-17',
                 description=dict(value='desc'),
                 title=dict(title='Project'),

--- a/cds/modules/records/serializers/schemas/video.py
+++ b/cds/modules/records/serializers/schemas/video.py
@@ -74,8 +74,8 @@ class VideoSchema(StrictKeysSchema):
     title = fields.Nested(TitleSchema, required=True)
     description = fields.Nested(DescriptionSchema, required=True)
     date = DateString(required=True)
-    category = fields.Str(required=True)
-    type = fields.Str(required=True)
+    category = fields.Str()
+    type = fields.Str()
 
     recid = fields.Number()
     _access = fields.Nested(AccessSchema)

--- a/tests/data/test_videos_projects.json
+++ b/tests/data/test_videos_projects.json
@@ -14,7 +14,27 @@
     },
     "$schema": "https://cdslabs.cern.ch/schemas/records/videos/video/video-v1.0.0.json",
     "type": "Type",
-    "category": "Category"
+    "category": "Category",
+    "contributors": [
+      {
+        "affiliations": [
+          "University of FuuBar"
+        ],
+        "email": "test_foo@cern.ch",
+        "ids": [
+          {
+            "source": "cern",
+            "value": "12345"
+          },
+          {
+            "source": "cds",
+            "value": "67890"
+          }
+        ],
+        "name": "Do, John",
+        "role": "Camera operator"
+      }
+    ]
   },
   {
     "date": "2017-01-16",
@@ -31,7 +51,28 @@
     },
     "$schema": "https://cdslabs.cern.ch/schemas/records/videos/video/video-v1.0.0.json",
     "type": "Type",
-    "category": "Category"
+    "category": "Category",
+    "contributors": [
+      {
+        "affiliations": [
+          "University of FuuBar"
+        ],
+        "email": "test_foo@cern.ch",
+        "ids": [
+          {
+            "source": "cern",
+            "value": "12345"
+          },
+          {
+            "source": "cds",
+            "value": "67890"
+          }
+        ],
+        "name": "Hello, World",
+        "role": "Camera operator"
+      }
+    ]
+
   },
   {
     "date": "2017-01-16",
@@ -48,7 +89,28 @@
     },
     "$schema": "https://cdslabs.cern.ch/schemas/records/videos/video/video-v1.0.0.json",
     "type": "Type",
-    "category": "Category"
+    "category": "Category",
+    "contributors": [
+      {
+        "affiliations": [
+          "University of FuuBar"
+        ],
+        "email": "test_foo@cern.ch",
+        "ids": [
+          {
+            "source": "cern",
+            "value": "124"
+          },
+          {
+            "source": "cds",
+            "value": "678"
+          }
+        ],
+        "name": "Fuu, Bar",
+        "role": "Camera operator"
+      }
+    ]
+
   },
   {
     "date": "2017-01-17",
@@ -64,6 +126,27 @@
     "type": "Type",
     "$schema": "https://cdslabs.cern.ch/schemas/records/videos/project/project-v1.0.0.json",
     "category": "Category",
-    "publication_date": "2017-03-09"
+    "publication_date": "2017-03-09",
+    "contributors": [
+      {
+        "affiliations": [
+          "University of FuuBar"
+        ],
+        "email": "test_foo@cern.ch",
+        "ids": [
+          {
+            "source": "cern",
+            "value": "135"
+          },
+          {
+            "source": "cds",
+            "value": "790"
+          }
+        ],
+        "name": "Test, Test2",
+        "role": "Camera operator"
+      }
+    ]
+
   }
 ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -387,6 +387,26 @@ def deposit_metadata():
         'date': '2016-12-03T00:00:00Z',
         'category': 'CERN',
         'type': 'MOVIE',
+        "contributors": [
+            {
+                "affiliations": [
+                    "University of FuuBar"
+                ],
+                "email": "test_foo@cern.ch",
+                "ids": [
+                    {
+                        "source": "cern",
+                        "value": "12345"
+                    },
+                    {
+                        "source": "cds",
+                        "value": "67890"
+                    }
+                ],
+                "name": "Do, John",
+                "role": "Camera operator"
+            }
+        ]
     }
 
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -36,7 +36,9 @@ import mock
 import pkg_resources
 from cds_sorenson.api import get_available_preset_qualities
 from celery import chain, group, shared_task, states
-from flask_security import login_user
+from flask_security import login_user, current_user
+from invenio_accounts.testutils import login_user_via_session
+from flask_principal import UserNeed, identity_loaded
 from invenio_accounts.models import User
 from invenio_db import db
 from invenio_files_rest.models import ObjectVersion, ObjectVersionTag

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -247,7 +247,7 @@ def workflow_receiver_video_failing(api_app, db, video,
 
 
 def new_project(app, es, cds_jsonresolver, users, location, db,
-                deposit_metadata, project_data=None):
+                deposit_metadata, project_data=None, wait=None):
     """New project with videos."""
     project_data = project_data or {
         'title': {
@@ -298,7 +298,8 @@ def new_project(app, es, cds_jsonresolver, users, location, db,
         video_2.commit()
 
     db.session.commit()
-    sleep(2)
+    if wait is not False:
+        sleep(2)
     return project, video_1, video_2
 
 

--- a/tests/unit/test_deposit_validation.py
+++ b/tests/unit/test_deposit_validation.py
@@ -38,7 +38,7 @@ from cds.modules.deposit.loaders.loader import MarshmallowErrors
 
 @pytest.mark.parametrize('remove_key, loader', [
     (key, loader)
-    for key in ['date', 'type', 'title.title']
+    for key in ['date', 'title.title']
     for loader in [project_loader, video_loader]
 ])
 def test_missing_fields(

--- a/tests/unit/test_project_rest.py
+++ b/tests/unit/test_project_rest.py
@@ -695,28 +695,28 @@ def test_default_order(api_app, es, cds_jsonresolver, users,
                                     location, db, deposit_metadata,
                                     project_data={
                                         'title': {'title': 'project 1'}
-                                    })
+                                    }, wait=False)
     project_1.commit()
     db.session.commit()
     (project_2, _, _) = new_project(api_app, es, cds_jsonresolver, users,
                                     location, db, deposit_metadata,
                                     project_data={
                                         'title': {'title': 'alpha'}
-                                    })
+                                    }, wait=False)
     project_2.commit()
     db.session.commit()
     (project_3, _, _) = new_project(api_app, es, cds_jsonresolver, users,
                                     location, db, deposit_metadata,
                                     project_data={
                                         'title': {'title': 'zeta'}
-                                    })
+                                    }, wait=False)
     project_3.commit()
     db.session.commit()
     (project_4, _, _) = new_project(api_app, es, cds_jsonresolver, users,
                                     location, db, deposit_metadata,
                                     project_data={
                                         'title': {'title': 'project 2'}
-                                    })
+                                    }, wait=False)
     project_4.commit()
     db.session.commit()
     sleep(2)
@@ -832,7 +832,7 @@ def test_aggregations(api_app, es, cds_jsonresolver, users,
         project_data={
             'title': {'title': 'project 1'},
             'category': 'CERN',
-        })
+        }, wait=False)
     #  project_1['_deposit']['state']['file_video_extract_frames'] = 'SUCCESS'
     project_1.commit()
     db.session.commit()
@@ -844,7 +844,7 @@ def test_aggregations(api_app, es, cds_jsonresolver, users,
             'description': {'value': 'fuu'},
             'category': 'CERN',
             'type': 'FOOTER',
-        })
+        }, wait=False)
     #  project_2['_deposit']['state']['file_video_extract_frames'] = 'FAILURE'
     prepare_videos_for_publish([video_1, video_2])
     project_2 = project_2.publish()
@@ -855,7 +855,7 @@ def test_aggregations(api_app, es, cds_jsonresolver, users,
         location, db, deposit_metadata,
         project_data={
             'title': {'title': 'zeta'},
-        })
+        }, wait=False)
     #  project_3['_deposit']['state']['file_video_extract_frames'] = 'SUCCESS'
     project_3['category'] = 'LHC'
     project_3.commit()
@@ -865,7 +865,7 @@ def test_aggregations(api_app, es, cds_jsonresolver, users,
         location, db, deposit_metadata,
         project_data={
             'title': {'title': 'project 2'},
-        })
+        }, wait=False)
     #  project_4['_deposit']['state']['file_video_extract_frames'] = 'SUCCESS'
     project_4['category'] = 'ATLAS'
     project_4.commit()

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -78,6 +78,13 @@ def test_drupal_serializer(video_record_metadata, deposit_metadata):
         'report_number': {'report_number': report_number},
         '$schema': Video.get_record_schema(),
         'duration': duration,
+        'contributors': [
+            {'name': 'paperone', 'role': 'Director'},
+            {'name': 'topolino', 'role': 'Music by'},
+            {'name': 'nonna papera', 'role': 'Producer'},
+            {'name': 'pluto', 'role': 'Director'},
+            {'name': 'zio paperino', 'role': 'Producer'}
+        ],
     })
     expected = dict(
         caption_en='in tempor reprehenderit enim eiusmod',


### PR DESCRIPTION
* Adds receiver permissions to have the same behaviour of deposit.
  (closes #869)

* Fixes synchronization of access rights from project to video.
  (addresses #889)

* Fixes contributors on tests.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>