### PR TITLE
webhooks: ignore videos with too high resolutions

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -739,10 +739,12 @@ def video_published(app, project_published):
 @pytest.fixture()
 def mock_sorenson():
     """Mock requests to the Sorenson server."""
-    def mocked_encoding(input_file, output_file, preset_name, aspect_ratio):
+    def mocked_encoding(input_file, output_file, preset_name, aspect_ratio,
+                        max_height=None, max_width=None):
         # Check if options are valid
         try:
-            get_preset_id(preset_name, aspect_ratio)
+            get_preset_id(preset_name, aspect_ratio, max_height=max_height,
+                          max_width=max_width)
         except InvalidResolutionError as e:
             raise e
 

--- a/tests/unit/test_webhook_views.py
+++ b/tests/unit/test_webhook_views.py
@@ -159,14 +159,18 @@ def check_video_transcode_delete(api_app, event_id, access_token,
                                  json_headers, data, video_1_id, video_1_depid,
                                  users):
     """Try to delete transcoded file via REST API."""
+    # get the list of task id of successfully transcode tasks
+    task_ids = [d['file_transcode']['id']
+                for d in data['global_status'][1]
+                if 'file_transcode' in d and
+                d['file_transcode']['status'] == 'SUCCESS']
     # DELETE FIRST TRANSCODED FILE
-    task_id = data['global_status'][1][1]['file_transcode']['id']
     with api_app.test_request_context():
         url = url_for(
             'invenio_webhooks.task_item',
             receiver_id='avc',
             event_id=event_id,
-            task_id=task_id,
+            task_id=task_ids[0],
             access_token=access_token
         )
     with api_app.test_client() as client, \
@@ -193,13 +197,12 @@ def check_video_transcode_delete(api_app, event_id, access_token,
     assert bucket.size == 0
 
     # DELETE SECOND TRANSCODED FILE
-    task_id = data['global_status'][1][2]['file_transcode']['id']
     with api_app.test_request_context():
         url = url_for(
             'invenio_webhooks.task_item',
             receiver_id='avc',
             event_id=event_id,
-            task_id=task_id,
+            task_id=task_ids[1],
             access_token=access_token
         )
     with api_app.test_client() as client, \


### PR DESCRIPTION
* Ignores videos with too high resolutions. (closes #949)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>