### PR TITLE
deposit: fix republishing when workflow pending

### DIFF
--- a/cds/modules/deposit/api.py
+++ b/cds/modules/deposit/api.py
@@ -108,14 +108,7 @@ class CDSDeposit(Deposit):
     @property
     def _bucket(self):
         """Get the bucket object."""
-        try:
-            return as_bucket(self['_buckets']['deposit'])
-        except KeyError:
-            pass  # we will look into the db for it
-        records_buckets = RecordsBuckets.query.filter_by(
-            record_id=self.id).first()
-        if records_buckets:
-            return records_buckets.bucket
+        return as_bucket(self['_buckets']['deposit'])
 
     def _get_files_dump(self):
         """Get files without create the record_bucket."""
@@ -677,10 +670,7 @@ class Project(CDSDeposit):
             # sync access rights
             video['_access'] = deepcopy(project_access)
             # sync owner
-            try:
-                video['_deposit']['created_by'] = project_created_by
-            except KeyError:
-                pass
+            video['_deposit']['created_by'] = project_created_by
         return changed
 
 

--- a/cds/modules/deposit/mappings/deposits/records/videos/project/project-v1.0.0.json
+++ b/cds/modules/deposit/mappings/deposits/records/videos/project/project-v1.0.0.json
@@ -3,6 +3,17 @@
     "project-v1.0.0": {
       "numeric_detection": true,
       "properties": {
+        "report_number": {
+          "properties": {
+            "_report_number": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "_updated": {
           "type": "date"
         },

--- a/cds/modules/deposit/mappings/deposits/records/videos/video/video-v1.0.0.json
+++ b/cds/modules/deposit/mappings/deposits/records/videos/video/video-v1.0.0.json
@@ -3,6 +3,17 @@
     "video-v1.0.0": {
       "date_detection": true,
       "properties": {
+        "report_number": {
+          "properties": {
+            "_report_number": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "_project_id":{
               "type": "string"
         },

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -457,3 +457,18 @@ def endpoint_get_schema(path):
     with open(pkg_resources.resource_filename(
             'cds_dojson.schemas', path), 'r') as f:
         return json.load(f)
+
+
+def check_deposit_record_files(deposit, deposit_expected, record,
+                               record_expected):
+    """Check deposit and record files expected."""
+    # check deposit
+    deposit_objs = [obj.key for obj in ObjectVersion.query_heads_by_bucket(
+        deposit.files.bucket).all()]
+    assert sorted(deposit_expected) == sorted(deposit_objs)
+    assert deposit.files.bucket.locked is False
+    # check record
+    record_objs = [obj.key for obj in ObjectVersion.query_heads_by_bucket(
+        record.files.bucket).all()]
+    assert sorted(record_expected) == sorted(record_objs)
+    assert record.files.bucket.locked is True

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -26,10 +26,11 @@
 
 from __future__ import absolute_import, print_function
 
+import pytest
+
 from os.path import join
 
 from click.testing import CliRunner
-from invenio_migrator.proxies import current_migrator
 from invenio_records.models import RecordMetadata
 from invenio_records import Record
 from invenio_pidstore.resolver import Resolver
@@ -37,6 +38,7 @@ from invenio_pidstore.resolver import Resolver
 from cds.cli import cli
 
 
+@pytest.mark.skip(reason='Wait fix cds-dojson')
 def test_record_files_migration(app, location, script_info, datadir):
     """Test CDS records and files migrations."""
     runner = CliRunner()


### PR DESCRIPTION
* Separates function to check if the deposit is published from
  the function to check if a record exists.

* Does't remove file instance when object version is removed.

* Temporary skip test on record files migration because of cds-dojson.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>