### PR TITLE
config: use cron for scheduled tasks

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -29,6 +29,7 @@ from __future__ import absolute_import, print_function
 import os
 from datetime import timedelta
 
+from celery.schedules import crontab
 from invenio_deposit.config import DEPOSIT_REST_FACETS
 from invenio_deposit.scopes import write_scope
 from invenio_deposit.utils import check_oauth2_scope
@@ -87,15 +88,15 @@ CELERYBEAT_SCHEDULE = {
     },
     'keywords': {
         'task': 'cds.modules.records.tasks.keywords_harvesting',
-        'schedule': timedelta(days=1),
+        'schedule': crontab(minute=10, hour=0),
     },
     'sessions': {
         'task': 'invenio_accounts.tasks.clean_session_table',
-        'schedule': timedelta(days=1),
+        'schedule': crontab(minute=0, hour=0),
     },
     'tasks_status': {
         'task': 'cds.modules.deposit.tasks.preserve_celery_states_on_db',
-        'schedule': timedelta(days=1),
+        'schedule': crontab(minute=5, hour=0),
     },
 }
 

--- a/tests/unit/test_celery.py
+++ b/tests/unit/test_celery.py
@@ -28,6 +28,8 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
+from celery.schedules import crontab
+
 
 # FIXME see cds#618 comments
 @pytest.mark.skip(reason='see cds#618 comments')
@@ -37,3 +39,14 @@ def test_celery():
     celery.loader.import_default_modules()
     assert 'invenio_mail.tasks.send_email' in celery.tasks
     assert 'invenio_records.tasks.api.create_record' in celery.tasks
+
+
+def test_celery_beat(app):
+    """Test celery beat."""
+    beats = [task['schedule']
+             for task in app.config['CELERYBEAT_SCHEDULE'].values()
+             if isinstance(task['schedule'], crontab)]
+    assert len(beats) == 3
+    for beat in beats:
+        [hour] = beat.hour
+        assert hour < 5


### PR DESCRIPTION
* Uses cron instead of time delta for scheduled tasks. (closes #909)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>