### PR TITLE
global: addition of number of record views

### DIFF
--- a/cds/modules/records/static/templates/cds_records/video/detail.html
+++ b/cds/modules/records/static/templates/cds_records/video/detail.html
@@ -88,7 +88,7 @@
                 <i class="fa fa-clock-o text-muted"></i> {{ ::record.metadata.duration }}
               </li>
               <li class="pull-right">
-                <i class="fa fa-eye text-muted"></i> 3000000
+                <i class="fa fa-eye text-muted"></i> {{ ::recordViews }}
               </li>
             </ul>
           </div>

--- a/cds/modules/records/templates/cds_records/record_detail.html
+++ b/cds/modules/records/templates/cds_records/record_detail.html
@@ -41,6 +41,7 @@
     <cds-record-view
         template="{{ url_for('static', filename='templates/cds_records/%s/detail.html' | format(type)) }}"
         record='/api/record/{{record.recid}}'
+        record-views='/api/stats/views/{{record.recid}}'
     ></cds-record-view>
   </div>
   <!-- Recent videos -->

--- a/cds/modules/stats/views.py
+++ b/cds/modules/stats/views.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2016, 2017 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""CDS Stats."""
+
+from __future__ import absolute_import, print_function
+
+from elasticsearch import Elasticsearch
+from flask import Blueprint, jsonify, make_response
+from flask.views import MethodView
+
+from cds.modules.records.permissions import record_read_permission_factory
+from invenio_records_rest.views import pass_record, need_record_permission
+
+# Legaciy code: once invenio-statistics is used, this code will be removed.
+CFG_ELASTICSEARCH_SEARCH_HOST = [{'host': '127.0.0.1', 'port': 9199}]
+ES_INDEX = 'cds-*'
+
+blueprint = Blueprint(
+    'cds_stats',
+    __name__,
+    url_prefix='/stats',
+)
+
+
+class ViewsStatsResource(MethodView):
+    """Statistics of number of views resource."""
+
+    def __init__(self):
+        """Init."""
+        self.read_permission_factory = record_read_permission_factory
+
+    @pass_record
+    @need_record_permission('read_permission_factory')
+    def get(self, pid, record, **kwargs):
+        """Handle GET request."""
+        page_views = 0
+        es = Elasticsearch(CFG_ELASTICSEARCH_SEARCH_HOST)
+        query = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "id_bibrec": pid.pid_value
+                            }
+                        },
+                        {
+                            "match": {
+                                "_type": "events.pageviews"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        results = es.count(index=ES_INDEX, body=query)
+        if results:
+            page_views = results.get('count', 0)
+        return make_response(jsonify(page_views), 200)
+
+
+blueprint.add_url_rule(
+    '/views/'
+    '<pid(recid, record_class="cds.modules.records.api:CDSRecord"):pid_value>',
+    view_func=ViewsStatsResource.as_view('views_stats')
+)

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,7 @@ setup(
         ],
         'invenio_base.api_blueprints': [
             'cds_records = cds.modules.records.views:blueprint',
+            'cds_stats = cds.modules.stats.views:blueprint',
         ],
         'invenio_base.apps': [
             'cds_deposit = cds.modules.deposit.ext:CDSDepositApp',


### PR DESCRIPTION
In order to test it, it requires a reverse proxy server (e.g. w/nginx) to query the ES cluster in production.
Also see cds-js/PR#11.


* Adds a new (legacy) module to query the number of views from the ES
  cluster in production and display them in the record page.
  (closes #928)

* Depends on the corresponding PR in cds-js.

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>