### PR TITLE
migration: add resolution tag to the slaves, fix smil file creation, update sequence counter

### DIFF
--- a/cds/config.py
+++ b/cds/config.py
@@ -38,6 +38,7 @@ from invenio_opendefinition.config import OPENDEFINITION_REST_ENDPOINTS
 from invenio_records_rest.facets import range_filter, terms_filter
 
 from .modules.deposit.facets import created_by_me_aggs
+from .modules.migrator.cli import dumps  # noqa
 from .modules.records.permissions import (deposit_delete_permission_factory,
                                           deposit_read_permission_factory,
                                           deposit_update_permission_factory,

--- a/cds/modules/migrator/cli.py
+++ b/cds/modules/migrator/cli.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Document Server.
+# Copyright (C) 2017 CERN.
+#
+# CERN Document Server is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Document Server is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Document Server; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Migration CLI."""
+
+from __future__ import absolute_import, print_function
+
+from invenio_db import db
+from invenio_migrator.cli import dumps
+from invenio_pidstore.models import PersistentIdentifier
+from invenio_sequencegenerator.api import Sequence
+from datetime import datetime
+from flask.cli import with_appcontext
+
+from ...modules.deposit.api import Project
+
+
+@dumps.command()
+@with_appcontext
+def sequence_generator():
+    """Update sequences according to current report numbers in pidstore."""
+    def get_pids(year):
+        """Get project and video pids registered this year."""
+        query = PersistentIdentifier.query.filter(
+            PersistentIdentifier.pid_value.contains('-{0}-'.format(year)))
+        pids = [pid.pid_value for pid in query.all()]
+        videos = [pid for pid in pids if pid.count('-') == 4]
+        projects = [pid for pid in pids if pid.count('-') == 3]
+        # check no pids are lost
+        assert sorted(pids) == sorted(projects + videos)
+        return projects, videos
+
+    def get_cats_types(projects, videos):
+        """Get category/type list for projects and videos."""
+        cats_types = set(
+            ["-".join(pid.split('-')[0:2]) for pid in projects])
+        cats_types_video = set(
+            ["-".join(pid.split('-')[0:2]) for pid in videos])
+        # check category/type list are the same
+        assert all([ct in cats_types for ct in cats_types_video])
+        return cats_types
+
+    def find_next(cat_type, pids):
+        max_count = max([
+            int(pid.split('-')[-1])
+            for pid in pids if pid.startswith(cat_type)])
+        return max_count + 1
+
+    def update_counter(next_counter, **sequence_kwargs):
+        """Update sequence counter."""
+        counter = Sequence(**sequence_kwargs).counter
+        counter.counter = next_counter
+        db.session.add(counter)
+        return counter
+
+    year = datetime.now().year
+    project_pids, video_pids = get_pids(year=year)
+    cats_types = get_cats_types(project_pids, video_pids)
+
+    for cat_type in cats_types:
+        [cat, type_] = cat_type.split('-')
+        update_counter(
+            next_counter=find_next(cat_type, project_pids), **{
+                'template': Project.sequence_name, 'year': year,
+                'category': cat, 'type': type_
+            })
+
+    db.session.commit()

--- a/cds/modules/migrator/records.py
+++ b/cds/modules/migrator/records.py
@@ -445,16 +445,18 @@ class CDSRecordDumpLoader(RecordDumpLoader):
                     if preset_name == name and \
                             all([options.get(key) == value
                                  for key, value in clues.items()]):
-                        return ratio, options
-            return None, None
+                        return ratio, preset_name, options
+            return None, None, None
 
         myclues = deepcopy(clues)
         preset = myclues.pop('preset', None)
         if preset:
-            ratio, preset = guess_preset(preset_name=preset, clues=myclues)
+            ratio, preset_quality, options = guess_preset(
+                preset_name=preset, clues=myclues)
             if ratio:
-                mypreset = deepcopy(preset)
+                mypreset = deepcopy(options)
                 mypreset['display_aspect_ratio'] = ratio
+                mypreset['preset_quality'] = preset_quality
                 return mypreset
         return {}
 

--- a/cds/modules/migrator/records.py
+++ b/cds/modules/migrator/records.py
@@ -47,7 +47,7 @@ from cds_dojson.marc21 import marc21
 from cds_dojson.marc21.utils import create_record
 from invenio_migrator.records import RecordDump, RecordDumpLoader
 
-from ..deposit.api import Project, Video, record_build_url, record_unbuild_url
+from ..deposit.api import Project, Video, record_build_url
 from ..deposit.tasks import datacite_register
 from ..records.api import CDSVideosFilesIterator, dump_generic_object
 from ..records.fetchers import report_number_fetcher
@@ -328,11 +328,14 @@ class CDSRecordDumpLoader(RecordDumpLoader):
             record_id=record.id, bucket_id=snapshot.id
         ))
         if Video.get_record_schema() == record['$schema']:
-            # create smil file
+            # create an empty smil file
             cls._resolve_dumps(record=record)
             cls._resolve_smil(record=record)
             # update tag 'master'
             cls._update_tag_master(record=record)
+            # create the full smil file
+            cls._resolve_dumps(record=record)
+            cls._resolve_smil(record=record)
 
     @classmethod
     def _get_bucket(cls, record):

--- a/tests/unit/test_migration.py
+++ b/tests/unit/test_migration.py
@@ -243,6 +243,13 @@ def test_migrate_record(app, location, datadir, es, users):
         for frame in master['frame']:
             assert float(frame['tags']['timestamp']) < duration
             assert float(frame['tags']['timestamp']) > 0
+        # check tag 'preset_quality'
+        pqs = [form['tags']['preset_quality'] for form in master['subformat']]
+        assert sorted(pqs) == sorted(['1080p', '240p', '360p', '480p', '720p'])
+        # check tag 'display_aspect_ratio'
+        dar = set([form['tags']['display_aspect_ratio']
+                   for form in master['subformat']])
+        assert dar == {'16:9'}
 
     # check video deposit
     deposit_video_uuid = PersistentIdentifier.query.filter(


### PR DESCRIPTION
* Adds `modified_by` on serializer.

* Converts the modified_by in the user_id. (addresses #991)

* Fixes smil file creation. (closes #1058)

* Adds the resolution tag on slaves. (closes #1059)

* Adds a new migration command to update sequence counter after
  migration. (closes #993)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>