### PR TITLE
sentry: update version to use sdk

### DIFF
--- a/requirements.packages.txt
+++ b/requirements.packages.txt
@@ -97,7 +97,7 @@ invenio-i18n==1.1.1
 invenio-iiif==1.0.0a5
 invenio-indexer==1.0.2
 invenio-jsonschemas==1.0.0
-invenio-logging==1.1.0
+invenio-logging==1.2.1
 invenio-mail==1.0.2
 invenio-migrator==1.0.0a10
 invenio-oaiserver==1.0.3
@@ -178,6 +178,7 @@ redis==2.10.6
 requests-oauthlib==1.1.0  # via flask-oauthlib, invenio-oauth2server, invenio-oauthclient
 requests[socks]==2.22.0
 scandir==1.10.0           # via pathlib2
+sentry-sdk==1.4.3
 simplegeneric==0.8.1      # via ipython
 simplejson==3.16.0        # via dojson, invenio-files-rest, webargs
 simplekv==0.12.0          # via flask-kvsession, invenio-accounts


### PR DESCRIPTION
closes #1848 

- Updated invenio-logging version and installed sentry-sdk
- Kept raven for fetching the release commit.