### PR TITLE
fix: deposit form bug

### DIFF
--- a/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/components/cdsDeposit.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/components/cdsDeposit.js
@@ -480,8 +480,10 @@ function cdsDepositCtrl(
       }
       that.currentStartedTaskName = currentStartedTaskName;
 
-      // Change the Deposit Status
-      var values = _.values(that.record._cds.state);
+      // Change the Deposit Status, ignore `file_video_extract_chapter_frames`
+      var values = _.values(
+        _.omit(that.record._cds.state, "file_video_extract_chapter_frames")
+      );
       if (!values.length) {
         that.currentDepositStatus = null;
       } else if (values.includes(depositStatuses.FAILURE)) {

--- a/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/filters/overallState.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/filters/overallState.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 
 function overallState(depositStatuses) {
   return function (tasks) {
-    var values = _.values(tasks);
+    var values = _.values(_.omit(tasks, "file_video_extract_chapter_frames"));
     if (values.length !== 0) {
       if (_.includes(values, "FAILURE")) {
         return depositStatuses.FAILURE;


### PR DESCRIPTION
Since `file_video_extract_chapter_frames` is not a [main task](https://github.com/CERNDocumentServer/cds-videos/blob/main/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/avc.module.js#L63), it's not in `depositStates` and `that.stateReporter`.  And it was failing during the status update