### PR TITLE
remove invenioFiles filters

### DIFF
--- a/cds/modules/theme/assets/bootstrap3/js/cds/module.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds/module.js
@@ -193,6 +193,28 @@ app.filter("toMinutes", function () {
   };
 });
 
+app.filter("bytesToHumanReadable", function () {
+  function filter(size) {
+    function round(num, precision) {
+      return Math.round(
+        num * Math.pow(10, precision)) / Math.pow(10, precision
+      );
+    }
+    var limit = Math.pow(1024, 4);
+    if (size > limit) {
+      return round(size / limit, 1) + ' TB';
+    } else if (size > (limit/=1024)) {
+      return round(size / limit, 1) + ' GB';
+    } else if (size > (limit/=1024)) {
+      return round(size / limit, 1) + ' MB';
+    } else if (size > 1024) {
+      return Math.round(size / 1024) +  ' KB';
+    }
+    return size + ' B';
+  }
+  return filter;
+});
+
 app.filter("findBy", function () {
   return function (data, key, value) {
     if (!_.isEmpty(data)) {

--- a/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/avc.module.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds_deposit/avc/avc.module.js
@@ -285,7 +285,6 @@ angular.module("cdsDeposit", [
   "mgcrea.ngStrap.tooltip",
   "ngFileUpload",
   "monospaced.elastic",
-  "invenioFiles.filters",
   "afkl.lazyImage",
   "hl.sticky",
   "duScroll",

--- a/cds/modules/theme/assets/bootstrap3/js/cds_records/app.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds_records/app.js
@@ -40,7 +40,6 @@ angular.element(document).ready(function () {
       "cds",
       "ngModal",
       "ngclipboard",
-      "invenioFiles.filters",
       "ngSanitize",
     ],
     { strictDi: true }

--- a/cds/modules/theme/webpack.py
+++ b/cds/modules/theme/webpack.py
@@ -77,6 +77,7 @@ theme = WebpackThemeBundle(
                 "invenio-search-js": "^1.5.4",
                 "invenio-charts-js": "^0.2.7",
                 "invenio-records-js": "~0.0.8",
+                # TODO: check if we can remove invenio-files-js
                 "invenio-files-js": "~0.0.2",
                 "ng-file-upload": "~12.0.4",
                 "jquery": "~3.2.1",


### PR DESCRIPTION
Overrode the [bytesToHumanReadable](https://github.com/inveniosoftware/invenio-files-js/blob/175550eb2d9c5f24c32437bd10201a34a02bd8e5/src/invenio-files-js/filters/bytesToHumanReadable.js#L31) filter from invenio-files-js because its unit formatting was incorrect.
- In invenio-files-js, file sizes were displayed as Kb, Mb, Gb, Tb(refer to bits).
- Updated all units to uppercase (KB, MB, GB, TB) to correctly represent bytes.

We should check if we can remove `invenio-files-js`