### PR TITLE
fix(serializer): do not remove HTML tags for titles

### DIFF
--- a/cds/modules/records/serializers/json.py
+++ b/cds/modules/records/serializers/json.py
@@ -31,7 +31,7 @@ from ..permissions import (
     has_read_record_eos_path_permission,
     has_read_record_permission,
 )
-from ..utils import HTMLTagRemover, parse_video_chapters, remove_html_tags
+from ..utils import HTMLTagRemover, parse_video_chapters
 from marshmallow_utils.html import sanitize_html, ALLOWED_HTML_ATTRS, ALLOWED_CSS_STYLES
 
 CUSTOM_ALLOWED_ATTRS = {
@@ -61,9 +61,6 @@ class CDSJSONSerializer(JSONSerializer):
             if "title" in metadata and "title" in metadata["title"]:
                 title = metadata["title"]["title"]
                 title = self.html_tag_remover.unescape(title)
-                metadata["title"]["title"] = remove_html_tags(
-                    self.html_tag_remover, title
-                )
 
             if "description" in metadata:
                 description = metadata["description"]
@@ -79,9 +76,6 @@ class CDSJSONSerializer(JSONSerializer):
                     if "title" in t and "title" in t["title"]:
                         t_title = t["title"]["title"]
                         t_title = self.html_tag_remover.unescape(t_title)
-                        t["title"]["title"] = remove_html_tags(
-                            self.html_tag_remover, t_title
-                        )
 
                     if "description" in t:
                         t_desc = t["description"]

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -158,7 +158,7 @@ def test_records_rest(
         res = client.get(url2, headers=json_headers)
         assert res.status_code == 200
         video_dict = json.loads(res.data.decode("utf-8"))
-        assert video_dict["metadata"]["title"]["title"] == "My english title"
+        assert video_dict["metadata"]["title"]["title"] == "My <b>english</b> title"
         expect_desc = "in tempor reprehenderit enim eiusmod <b><i>html</i></b>"
         assert video_dict["metadata"]["description"] == expect_desc
 

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -191,20 +191,13 @@ def test_cds_json_serializer_sanitization(video_record_metadata):
     assert 'Safe content' in description
     # Keep safe HTML tags like <b>
     assert '<b>bold</b>' in description
-    
-    # Remove everything in title
+
+    # Title: only unescape, no HTML tag removal
     title = result['metadata']['title']['title']
-    assert '<script>' not in title
-    assert '</script>' not in title
     assert 'Test' in title and 'Title' in title
-    assert '<b>' not in title
-    
-    # --- Translations checks ---
+    assert '<b>bold</b>' in title
+
+    # Translations: descriptions sanitized, titles only unescaped
     translations = result['metadata']['translations']
     for tr in translations:
-        # description
         assert '<script>' not in tr['description']
-        # title
-        assert '<script>' not in tr['title']['title']
-        assert '<b>' not in tr['title']['title']
-


### PR DESCRIPTION
If title contains special characters such as & (e.g. CERN examples - TI2&TI8 Building 140 and Injection Tunnels TI2&TI8) it's rendering as empty strings in the UI. 

Serializer sees them as malformed HTML entities and discards the content.

Since title already rendered as text we don't need to remove HTML tags.