### PR TITLE
fix(serializer):include hours in VTT timestamp formatting

### DIFF
--- a/cds/modules/records/serializers/vtt.py
+++ b/cds/modules/records/serializers/vtt.py
@@ -102,5 +102,5 @@ class VTT(object):
     def time_format(seconds):
         """Helper function to convert seconds to vtt time format."""
         d = datetime.utcfromtimestamp(seconds)
-        s = d.strftime("%M:%S.%f")
+        s = d.strftime("%H:%M:%S.%f")
         return s[:-3]

--- a/tests/unit/test_serializer.py
+++ b/tests/unit/test_serializer.py
@@ -87,7 +87,7 @@ def test_vtt_serializer(video_record_metadata):
     ]
 
     # Check first and last timestamp
-    assert start_times[0] == "00:00.000"
+    assert start_times[0] == "00:00:00.000"
     assert end_times[-1] == VTT.time_format(
         float(video_record_metadata["_files"][0]["tags"]["duration"])
     )


### PR DESCRIPTION
Previously timestamps were formatted as MM:SS.mmm, which dropped the hour component and caused incorrect thumbnail timings for videos longer than one hour.
