### PR TITLE
schema: normalize MARC tag keys to numeric format

### DIFF
--- a/cds/modules/records/serializers/schemas/common.py
+++ b/cds/modules/records/serializers/schemas/common.py
@@ -19,7 +19,15 @@
 
 """Common JSON schemas."""
 
-from marshmallow import RAISE, Schema, ValidationError, fields, validates_schema
+from marshmallow import (
+    RAISE,
+    Schema,
+    ValidationError,
+    fields,
+    post_load,
+    pre_load,
+    validates_schema,
+)
 from marshmallow.validate import Length
 from marshmallow_utils.fields import SanitizedHTML
 from marshmallow_utils.html import sanitize_html
@@ -176,6 +184,24 @@ class LegacyMARCFieldsSchema(Schema):
     tag_088 = fields.List(fields.Str(), data_key="088")
     tag_020 = fields.List(fields.Str(), data_key="020")
 
+    def _strip_tag_prefix(self, data):
+        """Shared logic to convert tag_XXX <-> XXX."""
+        transformed = {}
+        for key, value in data.items():
+            if key.startswith("tag_"):
+                transformed[key[4:]] = value
+            else:
+                transformed[key] = value
+        return transformed
+
+    @pre_load
+    def normalize_tag_keys(self, data, **kwargs):
+        return self._strip_tag_prefix(data)
+
+    @post_load
+    def restore_numeric_keys(self, data, **kwargs):
+        return self._strip_tag_prefix(data)
+
 
 class DigitizedMetadataSchema(Schema):
     url = fields.Str()
@@ -220,7 +246,9 @@ class CurationSchema(StrictKeysSchema):
     internal_note = fields.List(fields.Str())
     legacy_marc_fields = fields.Nested(LegacyMARCFieldsSchema)
     digitized = fields.List(fields.Nested(DigitizedMetadataSchema))
-    digitized_preservation = fields.List(fields.Nested(DigitizedPreservationMetadataSchema))
+    digitized_preservation = fields.List(
+        fields.Nested(DigitizedPreservationMetadataSchema)
+    )
     digitized_description = fields.List(fields.Str())
     digitized_language = fields.List(fields.Str())
     digitized_keywords = fields.List(fields.Str())


### PR DESCRIPTION
When editing a migrated video, the MARC fields are loaded using internal schema keys (e.g. tag_964) instead of the expected numeric format (964).  And this was causing Validation error.

See:
[tag_964](https://videos.cern.ch/search?page=1&size=21&q=_curation.legacy_marc_fields.tag_964:*)
[964](https://videos.cern.ch/search?page=1&size=21&q=_curation.legacy_marc_fields.964:*)

Added @pre_load hook to normalize tag_XXX → XXX before deserialization
Added @post_load hook to convert internal tag_XXX → XXX after deserialization