### PR TITLE
release: v2.12.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@
 Changes
 =======
 
+Version 2.12.0 (2026-04-08)
+
+- schema: normalize MARC tag keys to numeric format in serializer
+- schema: add new curation fields for digitized videos
+- requirements: bump invenio-files-rest to allow range requests
+
 Version 2.11.1 (2026-03-17)
 
 - fix(serializer): include hours in VTT timestamp formatting

--- a/cds/version.py
+++ b/cds/version.py
@@ -24,4 +24,4 @@
 
 """CDS version."""
 
-__version__ = "2.11.1"
+__version__ = "2.12.0"


### PR DESCRIPTION
- [x] Update indexes after deployment:
    ```bash
    invenio index update --no-check records-videos-video-video-v1.0.0
    invenio index update --no-check deposits-records-videos-video-video-v1.0.0
    ```