### PR TITLE
sanitizer: allow href and link in ckeditor

### DIFF
--- a/cds/modules/deposit/static/json/cds_deposit/forms/video.json
+++ b/cds/modules/deposit/static/json/cds_deposit/forms/video.json
@@ -22,7 +22,7 @@
             "forcePasteAsPlainText": false,
             "extraAllowedContent": "*{color}; *[style]",
             "disableAutoInline": true,
-            "extraPlugins": "colorbutton",
+            "extraPlugins": "colorbutton,link",
             "toolbar": [
               [
                 "PasteText",
@@ -35,6 +35,10 @@
                 "-",
                 "Subscript",
                 "Superscript"
+              ],
+              [
+                "Link",
+                "Unlink"
               ],
               [
                 "TextColor"

--- a/cds/modules/records/serializers/json.py
+++ b/cds/modules/records/serializers/json.py
@@ -36,6 +36,7 @@ from marshmallow_utils.html import sanitize_html, ALLOWED_HTML_ATTRS, ALLOWED_CS
 
 CUSTOM_ALLOWED_ATTRS = {
     **ALLOWED_HTML_ATTRS,
+    "a": ALLOWED_HTML_ATTRS.get("a", []) + ["href", "title", "target", "rel"],
     "span": ALLOWED_HTML_ATTRS.get("span", []) + ["style"],
     "p": ALLOWED_HTML_ATTRS.get("p", []) + ["style"],
 }

--- a/cds/modules/theme/assets/bootstrap3/js/cds_deposit/ckeditor-sanitizer.js
+++ b/cds/modules/theme/assets/bootstrap3/js/cds_deposit/ckeditor-sanitizer.js
@@ -44,7 +44,7 @@ var sanitizeConfig = {
     "u",
     "ul",
   ],
-  ALLOWED_ATTR: ["style", "dir", "lang", "color"],
+  ALLOWED_ATTR: ["style", "dir", "lang", "color", "href", "title", "target", "rel"],
   ALLOW_STYLE: true,
   ALLOW_DATA_ATTR: false,
 };


### PR DESCRIPTION
Allow users to add link using the ckeditor. without adding the link urls still will not work in the record landing page

<img width="587" height="110" alt="image" src="https://github.com/user-attachments/assets/9c1fd07f-4130-4b30-9303-5f2eb7cfe5c3" />

