### PR TITLE
fix(frames): correct extracted frame timestamp calculation

### DIFF
--- a/cds/modules/flows/tasks.py
+++ b/cds/modules/flows/tasks.py
@@ -705,7 +705,7 @@ class ExtractFramesTask(AVCTask):
                 media_type="image",
                 context_type="frame",
                 master_id=object_.version_id,
-                timestamp=start_time + (i + 1) * time_step,
+                timestamp=start_time + i * time_step,
             )
             for i, filename in enumerate(frames)
         ]


### PR DESCRIPTION
Frame timestamps were calculated with start_time + (i + 1) * time_step. Because enumerate(frames) starts at i = 0, the very first extracted frame was being stored with a timestamp one full step later than its actual position in the video.

Example:
start_time = 5s
time_step = 10s
extracted frames correspond to positions 5s, 15s, 25s, ...

(i + 1) logic stored them as:
- frame 0 → 15s
- frame 1 → 25s
- frame 2 → 35s

This means every frame timestamp was shifted forward by one interval.

