### PR TITLE
fix(ui): wrap long related identifiers

### DIFF
--- a/cds/modules/records/static/templates/cds_records/video/detail.html
+++ b/cds/modules/records/static/templates/cds_records/video/detail.html
@@ -314,7 +314,7 @@
                       <span ng-if="ri.resource_type">
                         {{ ri.resource_type | format_relation_resource_type }}:
                       </span>
-                      <a ng-href="{{ ri.url }}" target="_blank">{{ ri.identifier }}</a>
+                      <a class="cds-text-break" ng-href="{{ ri.url }}" target="_blank">{{ ri.identifier }}</a>
                       ({{ ri.scheme }})
                     </li>
                   </ul>

--- a/cds/modules/theme/assets/bootstrap3/scss/cds/cds.scss
+++ b/cds/modules/theme/assets/bootstrap3/scss/cds/cds.scss
@@ -255,6 +255,13 @@ a.cds-anchor:hover{
   display: block;
 }
 
+.cds-text-break {
+  display: inline-block;
+  max-width: 100%;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 // Tags
 
 .cds-tags ul {


### PR DESCRIPTION
example:
https://videos.cern.ch/record/3000784
before:
<img width="1032" height="436" alt="Screenshot 2026-04-24 at 17 03 55" src="https://github.com/user-attachments/assets/95e84c4a-8639-4535-95c9-058f049e0fbb" />
after:
<img width="928" height="213" alt="Screenshot 2026-04-24 at 17 04 04" src="https://github.com/user-attachments/assets/606265cb-cd85-4e0c-9f2b-8167ee5ce421" />
